### PR TITLE
Implement dockerized building and running of CGW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.77.0 as builder
+LABEL Description="OpenLan CGW (Build) environment"
+
+WORKDIR /usr/src/openlan-cgw
+
+RUN rustup target add x86_64-unknown-linux-gnu
+
+RUN apt-get update -q -y  && apt-get install -q -y \
+	pkg-config \
+	build-essential \
+	cmake \
+	protobuf-compiler \
+	libssl-dev
+
+CMD ["make", "-C", "/usr/src/openlan-cgw", "cgw-app"]
+
+FROM busybox:glibc as cgw-img
+COPY --from=builder /lib/x86_64-linux-gnu/ /lib/x86_64-linux-gnu/
+COPY output/bin/ucentral-cgw /usr/local/bin/ucentral-cgw
+CMD ["ucentral-cgw"]

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,68 @@
-app_name := ucentral-cgw
+.ONESHELL:
+SHELL = /bin/bash
+.SHELLFLAGS += -e
 
-all: output/bin/${app_name}
-	@echo "uCentral CGW build app done"
+CGW_IMG_ID := openlan-cgw-img
+CGW_IMG_TAG := $(shell \
+	if [[ `git status --porcelain --untracked-files=no` ]]; then \
+		echo "`git rev-parse --short HEAD`-dirty"; \
+	else \
+		echo "`git rev-parse --short HEAD`"; \
+	fi)
+CGW_IMG_CONTAINER_NAME := "openlan_cgw"
 
-clean:
-	rm -rf ./output/
+CGW_BUILD_ENV_IMG_ID := openlan-cgw-build-env
+CGW_BUILD_ENV_IMG_TAG := $(shell cat Dockerfile | sha1sum | awk '{print substr($$1,0,11);}')
 
-run: output/bin/${app_name}
-	./run_cgw.sh
+CGW_BUILD_ENV_IMG_CONTAINER_NAME := "cgw_build_env"
 
-# TODO: replace this find with actual --out-dir for cargo
-# however, as of now it's an unstable flag, hence gotta do it
-# in a bash-ish way.
-output/bin/${app_name}:
-	@rm output/bin/${app_name} || true;
-	@mkdir output/bin || true;
-	@cargo build --target-dir ./output &&\
-		find ./output/ -name "${app_name}" -exec cp {} ./output/bin/ -f \;
+.PHONY: all cgw-app cgw-build-env-img cgw-img stop clean run
+
+all: cgw-build-env-img cgw-img
+	@echo "uCentral CGW build app (container) done"
+
+# Executed inside build-env
+cgw-app:
+	cargo build --target x86_64-unknown-linux-gnu --release
+
+# Builds build-env image itself
+cgw-build-env-img:
+	@echo "Trying to build build-env-img, looking if exists.."
+	@docker inspect --type=image ${CGW_BUILD_ENV_IMG_ID}:${CGW_BUILD_ENV_IMG_TAG} >/dev/null 2>&1 || \
+		(echo "build-env-img doesn't exist, building..." && \
+		docker build --file Dockerfile \
+		--tag ${CGW_BUILD_ENV_IMG_ID}:${CGW_BUILD_ENV_IMG_TAG} \
+		--target builder \
+		.)
+	@echo "build-env-img build done"
+
+# Generates both build-env img as well as CGW result docker img
+# Uses local FS / project dir for storing cache for build etc
+cgw-img: stop cgw-build-env-img
+	@mkdir -p output/bin > /dev/null 2>&1 || true
+	@docker run -it --name ${CGW_BUILD_ENV_IMG_CONTAINER_NAME} --network=host \
+		-v `realpath ./`:/usr/src/openlan-cgw \
+		${CGW_BUILD_ENV_IMG_ID}:${CGW_BUILD_ENV_IMG_TAG}
+	@docker cp ${CGW_BUILD_ENV_IMG_CONTAINER_NAME}:/usr/src/openlan-cgw/target/x86_64-unknown-linux-gnu/release/ucentral-cgw ./output/bin
+	@docker build --file Dockerfile \
+		--tag ${CGW_IMG_ID}:${CGW_IMG_TAG} \
+		--target cgw-img \
+		.
+	@echo Docker build done;
+
+stop:
+	@echo "Stopping / removing container ${CGW_IMG_CONTAINER_NAME}"
+	@docker stop ${CGW_IMG_CONTAINER_NAME} > /dev/null 2>&1 || true;
+	@docker container rm ${CGW_IMG_CONTAINER_NAME} > /dev/null 2>&1 || true;
+	@echo "Stopping / removing container ${CGW_BUILD_ENV_IMG_CONTAINER_NAME}"
+	@docker stop ${CGW_BUILD_ENV_IMG_CONTAINER_NAME} > /dev/null 2>&1 || true;
+	@docker container rm ${CGW_BUILD_ENV_IMG_CONTAINER_NAME} > /dev/null 2>&1 || true;
+
+clean: stop
+	@echo Cleaning build env and artifacts...
+	@docker rmi ${CGW_IMG_ID}:${CGW_IMG_TAG} >/dev/null 2>&1 || true
+	@docker rmi ${CGW_BUILD_ENV_IMG_ID}:${CGW_BUILD_ENV_IMG_TAG} >/dev/null 2>&1 || true
+	@echo Done!
+
+run: stop cgw-img
+	@./run_cgw.sh "${CGW_IMG_ID}:${CGW_IMG_TAG}" ${CGW_IMG_CONTAINER_NAME}

--- a/run_cgw.sh
+++ b/run_cgw.sh
@@ -27,6 +27,8 @@ KAFKA_IP="${CGW_KAFKA_IP:-$DEFAULT_KAFKA_IP}"
 KAFKA_PORT="${CGW_KAFKA_PORT:-$DEFAULT_KAFKA_PORT}"
 DB_IP="${CGW_DB_IP:-$DEFAULT_DB_IP}"
 DB_PORT="${CGW_DB_PORT:-$DEFAULT_DB_PORT}"
+DB_USR="${CGW_DB_USER:-cgw}"
+DB_PASS="${CGW_DB_PASS:-123}"
 REDIS_DB_IP="${CGW_REDIS_DB_IP:-$DEFAULT_REDIS_DB_IP}"
 REDIS_DB_PORT="${CGW_REDIS_DB_PORT:-$DEFAULT_REDIS_DB_PORT}"
 LOG_LEVEL="${CGW_LOG_LEVEL:-info}"
@@ -40,12 +42,12 @@ echo "KAFKA: $KAFKA_IP:$KAFKA_PORT"
 echo "DB: $DB_IP:$DB_PORT"
 echo "REDIS_DB: $REDIS_DB_IP:$REDIS_DB_PORT"
 
-# TBD: docker-based run
-# TBD 2: add num of thread cfg (start argument)
-output/bin/ucentral-cgw -w 4 -c $ID \
+# TBD: add num of thread cfg (start argument)
+docker run -d -t --network=host --name $2 $1 ucentral-cgw \
 	--grpc-ip $GRPC_IP --grpc-port $GRPC_PORT \
 	--wss-ip $WSS_LOCAL_IP --wss-port $WSS_LOCAL_PORT \
 	--kafka-ip $KAFKA_IP --kafka-port $KAFKA_PORT \
 	--db-ip $DB_IP --db-port $DB_PORT \
+	--db-username $DB_USR --db-password $DB_PASS \
 	--redis-db-ip $REDIS_DB_IP --redis-db-port $REDIS_DB_PORT \
 	$LOG_LEVEL

--- a/src/cgw_connection_server.rs
+++ b/src/cgw_connection_server.rs
@@ -1,8 +1,10 @@
+use crate::cgw_devices_cache::CGWDevice;
 use crate::AppArgs;
 
 use crate::{
     cgw_connection_processor::{CGWConnectionProcessor, CGWConnectionProcessorReqMsg},
     cgw_db_accessor::CGWDBInfrastructureGroup,
+    cgw_devices_cache::CGWDevicesCache,
     cgw_metrics::{CGWMetrics, CGWMetricsCounterOpType, CGWMetricsCounterType},
     cgw_nb_api_listener::CGWNBApiClient,
     cgw_remote_discovery::CGWRemoteDiscovery,
@@ -113,6 +115,10 @@ pub struct CGWConnectionServer {
     // Handler that helps this object to wrap relayed NB-API messages
     // dedicated for this particular local CGW instance
     mbox_relayed_messages_handle: CGWConnectionServerNBAPIMboxTx,
+
+    // Internal CGW Devices cache
+    // Key: device MAC, Value: Device
+    devices_cache: Arc<RwLock<CGWDevicesCache>>,
 }
 
 /*
@@ -213,6 +219,7 @@ impl CGWConnectionServer {
             cgw_remote_discovery: Arc::new(CGWRemoteDiscovery::new(app_args).await),
             mbox_relayed_messages_handle: nb_api_tx,
             mbox_relay_msg_runtime_handle: relay_msg_mbox_runtime_handle,
+            devices_cache: Arc::new(RwLock::new(CGWDevicesCache::new())),
         });
 
         let server_clone = server.clone();
@@ -226,6 +233,10 @@ impl CGWConnectionServer {
             server_clone.process_internal_nb_api_mbox(nb_api_rx).await;
         });
 
+        // Sync RAM cache with PostgressDB.
+        server.cgw_remote_discovery.sync_device_to_gid_cache(server.devices_cache.clone()).await;
+        server.devices_cache.write().await.dump_devices_cache();
+
         server
     }
 
@@ -233,9 +244,15 @@ impl CGWConnectionServer {
         let _ = self.mbox_internal_tx.send(req);
     }
 
-    pub fn enqueue_mbox_message_from_device_to_nb_api_c(&self, _mac: DeviceSerial, req: String) {
-        // TODO: device (mac) -> group id matching
-        let key = String::from("TBD_INFRA_GROUP");
+    pub fn enqueue_mbox_message_from_device_to_nb_api_c(&self, mac: DeviceSerial, req: String) {
+        let device_id = self
+            .devices_cache
+            .try_read()
+            .unwrap()
+            .get_device_from_cache_device_id(&mac.to_string())
+            .unwrap();
+
+        let key = device_id.to_string();
         let nb_api_client_clone = self.nb_api_client.clone();
         tokio::spawn(async move {
             let _ = nb_api_client_clone
@@ -656,9 +673,10 @@ impl CGWConnectionServer {
                                     format!("Failed to insert MACs from infra list, gid {gid}, uuid {uuid}: group does not exist."));
                             }
 
+                            let lock = self.devices_cache.clone();
                             match self
                                 .cgw_remote_discovery
-                                .create_ifras_list(gid, mac_list)
+                                .create_ifras_list(gid, mac_list, lock)
                                 .await
                             {
                                 Ok(()) => {
@@ -688,9 +706,10 @@ impl CGWConnectionServer {
                                     format!("Failed to delete MACs from infra list, gid {gid}, uuid {uuid}: group does not exist."));
                             }
 
+                            let lock = self.devices_cache.clone();
                             match self
                                 .cgw_remote_discovery
-                                .destroy_ifras_list(gid, mac_list)
+                                .destroy_ifras_list(gid, mac_list, lock)
                                 .await
                             {
                                 Ok(()) => {
@@ -834,6 +853,12 @@ impl CGWConnectionServer {
                                 CGWConnectionProcessorReqMsg::AddNewConnectionShouldClose;
                             c.send(msg).unwrap();
                         });
+                        // Chech if device exist and remove it from cache
+                        let mut devices_cache = self.devices_cache.write().await;
+                        if devices_cache.check_device_exists_in_cache(&serial) {
+                            devices_cache.del_device_from_cache(&serial);
+                            devices_cache.dump_devices_cache();
+                        }
                     } else {
                         CGWMetrics::get_ref().change_counter(
                             CGWMetricsCounterType::ConnectionsNum,
@@ -850,6 +875,11 @@ impl CGWConnectionServer {
                         serial,
                         connmap_w_lock.len() + 1
                     );
+
+                    let mut devices_cache = self.devices_cache.write().await;
+                    devices_cache.add_device_to_cache(&serial, &CGWDevice::new(0));
+                    devices_cache.dump_devices_cache();
+
                     connmap_w_lock.insert(serial, conn_processor_mbox_tx);
 
                     tokio::spawn(async move {
@@ -863,6 +893,10 @@ impl CGWConnectionServer {
                         serial,
                         connmap_w_lock.len() - 1
                     );
+                    // delete device from cache
+                    let mut devices_cache = self.devices_cache.write().await;
+                    devices_cache.del_device_from_cache(&serial);
+                    devices_cache.dump_devices_cache();
                     connmap_w_lock.remove(&serial);
                     CGWMetrics::get_ref().change_counter(
                         CGWMetricsCounterType::ConnectionsNum,
@@ -888,7 +922,6 @@ impl CGWConnectionServer {
         // Only ACK connection. We will either drop it or accept it once processor starts
         // (we'll handle it via "mailbox" notify handle in process_internal_mbox)
         let server_clone = self.clone();
-
         self.wss_rx_tx_runtime.spawn(async move {
             // Accept the TLS connection.
             let tls_stream = match tls_acceptor.accept(socket).await {

--- a/src/cgw_db_accessor.rs
+++ b/src/cgw_db_accessor.rs
@@ -221,4 +221,26 @@ impl CGWDBAccessor {
             }
         }
     }
+
+    pub async fn get_all_infras(&self) -> Option<Vec<CGWDBInfra>> {
+        let mut list: Vec<CGWDBInfra> = Vec::new();
+
+        let res = self
+            .cl
+            .query("SELECT * from infras", &[])
+            .await;
+
+        match res {
+            Ok(r) => {
+                for x in r {
+                    let infra = CGWDBInfra::from(x);
+                    list.push(infra);
+                }
+                return Some(list);
+            }
+            Err(_e) => {
+                return None;
+            }
+        }
+    }
 }

--- a/src/cgw_devices_cache.rs
+++ b/src/cgw_devices_cache.rs
@@ -1,0 +1,122 @@
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::{collections::HashMap, io::Write};
+
+type DevicesCacheType = HashMap<String, CGWDevice>;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CGWDevice {
+    group_id: i32,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CGWDevicesCache {
+    cache: DevicesCacheType,
+}
+
+impl CGWDevice {
+    pub fn new(group_id: i32) -> CGWDevice {
+        CGWDevice { group_id }
+    }
+
+    pub fn set_device_group_id(&mut self, group_id: i32) {
+        self.group_id = group_id;
+    }
+
+    pub fn get_device_group_id(&self) -> i32 {
+        self.group_id
+    }
+}
+
+impl CGWDevicesCache {
+    pub fn new() -> CGWDevicesCache {
+        let cache = DevicesCacheType::new();
+        CGWDevicesCache { cache }
+    }
+
+    pub fn add_device_to_cache(&mut self, key: &String, value: &CGWDevice) -> bool {
+        let status: bool;
+
+        if self.check_device_exists_in_cache(key) {
+            debug!(
+                "Failed to add device {}. Requested item already exist.",
+                key
+            );
+            status = false;
+        } else {
+            self.cache.insert(key.clone(), value.clone());
+            status = true;
+        }
+
+        status
+    }
+
+    pub fn del_device_from_cache(&mut self, key: &String) -> bool {
+        let status: bool;
+
+        if self.check_device_exists_in_cache(key) {
+            self.cache.remove(key);
+            status = true;
+        } else {
+            debug!(
+                "Failed to del device {}. Requested item does not exist.",
+                key
+            );
+            status = false;
+        }
+
+        status
+    }
+
+    pub fn check_device_exists_in_cache(&self, key: &String) -> bool {
+        let status: bool;
+        match self.cache.get(key) {
+            Some(_) => status = true,
+            None => status = false,
+        }
+
+        status
+    }
+
+    pub fn update_device_from_cache_device_id(&mut self, key: &String, group_id: i32) -> bool {
+        let status: bool;
+
+        if let Some(value) = self.cache.get_mut(key) {
+            (*value).set_device_group_id(group_id);
+            status = true;
+        } else {
+            debug!(
+                "Failed to update device {} id. Requested item does not exist.",
+                key
+            );
+            status = false;
+        }
+
+        status
+    }
+
+    pub fn get_device_from_cache_device_id(&self, key: &String) -> Option<i32> {
+        if let Some(value) = self.cache.get(key) {
+            Some(value.get_device_group_id())
+        } else {
+            None
+        }
+    }
+
+    pub fn dump_devices_cache(&self) {
+        let json_output = serde_json::to_string_pretty(&self).unwrap();
+        let file_path: String = "/var/devices_cache.json".to_string();
+
+        debug!("Cache: {}", json_output);
+
+        let mut fd = File::create(file_path).expect("Failed to create dump file!");
+        fd.write(json_output.as_bytes())
+            .expect("Failed to write dump!");
+    }
+}
+
+impl Drop for CGWDevicesCache {
+    fn drop(&mut self) {
+        self.dump_devices_cache();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 mod cgw_connection_processor;
 mod cgw_connection_server;
 mod cgw_db_accessor;
+mod cgw_devices_cache;
 mod cgw_metrics;
 mod cgw_nb_api_listener;
 mod cgw_remote_client;


### PR DESCRIPTION
- Use special build-env docker image that uses local project directory (volume mount) to speedup build.
- Implement cgw-img (docker image) generation.
- Track cgw-img tag based on commit.