### PR TITLE
Fix invalid device MAC reporting upon connect

### DIFF
--- a/src/cgw_connection_server.rs
+++ b/src/cgw_connection_server.rs
@@ -366,7 +366,7 @@ impl CGWConnectionServer {
             }
             "infrastructure_group_device_message" => {
                 let json_msg: InfraGroupMsgJSON = serde_json::from_str(&pload).unwrap();
-                //debug!("{:?}", json_msg);
+                debug!("{:?}", json_msg);
                 return Some(CGWNBApiParsedMsg::InfrastructureGroupInfraMsg(
                     json_msg.uuid,
                     group_id,


### PR DESCRIPTION
- Rework JSON parser of uCentral messages to report valid mac to conn_server (in hex + uppercase), either way, connmap lookup can fail and cgw is unable to forward (sink down) msg from NB API to device;
- Comment-out stale connection closing (for now);