### PR TITLE
Fix CGW docker container not starting sometimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -q -y  && apt-get install -q -y \
 
 CMD ["make", "-C", "/usr/src/openlan-cgw", "cgw-app"]
 
-FROM busybox:glibc as cgw-img
+FROM rust:1.77.0 as cgw-img
 COPY --from=builder /lib/x86_64-linux-gnu/ /lib/x86_64-linux-gnu/
 COPY output/bin/ucentral-cgw /usr/local/bin/ucentral-cgw
 CMD ["ucentral-cgw"]


### PR DESCRIPTION
Base busybox image seems to be unstable across different platforms. Change it (for now) to be using base RUST image to at least make it 100% working across different setups.