### PR TITLE
Dev prio messages queue

### DIFF
--- a/src/cgw_ucentral_ap_parser.rs
+++ b/src/cgw_ucentral_ap_parser.rs
@@ -1,10 +1,9 @@
-use std::str::FromStr;
-
 use base64::prelude::*;
 use eui48::MacAddress;
 use flate2::read::ZlibDecoder;
 use serde_json::Value;
 use std::io::prelude::*;
+use std::str::FromStr;
 
 use crate::cgw_ucentral_parser::{
     CGWUCentralEvent, CGWUCentralEventConnect, CGWUCentralEventConnectParamsCaps,

--- a/src/cgw_ucentral_messages_queue_manager.rs
+++ b/src/cgw_ucentral_messages_queue_manager.rs
@@ -1,8 +1,76 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
+use tokio::time;
 
 use crate::cgw_ucentral_parser::{CGWUCentralCommand, CGWUCentralCommandType};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum CGWUCentralMessagesQueueState {
+    Rx,
+    #[default]
+    RxTx,
+    Discard,
+}
+
+struct CGWUCentralMessagesQueue {
+    queue: VecDeque<CGWUCentralMessagesQueueItem>,
+    queue_state: CGWUCentralMessagesQueueState,
+    last_req_id: u64,
+    last_req_timeout: Duration,
+}
+
+impl CGWUCentralMessagesQueue {
+    fn new() -> Self {
+        CGWUCentralMessagesQueue {
+            queue: VecDeque::<CGWUCentralMessagesQueueItem>::new(),
+            queue_state: CGWUCentralMessagesQueueState::default(),
+            last_req_id: 0,
+            last_req_timeout: Duration::ZERO,
+        }
+    }
+
+    fn set_state(&mut self, state: CGWUCentralMessagesQueueState) {
+        self.queue_state = state;
+    }
+
+    fn get_state(&self) -> CGWUCentralMessagesQueueState {
+        self.queue_state
+    }
+
+    fn get_item(&self, index: usize) -> Option<&CGWUCentralMessagesQueueItem> {
+        self.queue.get(index)
+    }
+
+    fn set_last_req_id(&mut self, req_id: u64) {
+        self.last_req_id = req_id;
+    }
+
+    fn get_last_req_id(&self) -> u64 {
+        self.last_req_id
+    }
+
+    fn set_last_req_timeout(&mut self, req_timeout: Duration) {
+        self.last_req_timeout = req_timeout;
+    }
+
+    fn remove_item(&mut self, index: usize) -> Option<CGWUCentralMessagesQueueItem> {
+        self.queue.remove(index)
+    }
+
+    fn insert_item(&mut self, index: usize, value: CGWUCentralMessagesQueueItem) {
+        self.queue.insert(index, value)
+    }
+
+    fn push_back_item(&mut self, value: CGWUCentralMessagesQueueItem) {
+        self.queue.push_back(value)
+    }
+
+    fn queue_len(&self) -> usize {
+        self.queue.len()
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct CGWUCentralMessagesQueueItem {
@@ -11,32 +79,31 @@ pub struct CGWUCentralMessagesQueueItem {
 }
 
 impl CGWUCentralMessagesQueueItem {
-    pub fn new(
-        command: CGWUCentralCommand,
-        message: String,
-    ) -> CGWUCentralMessagesQueueItem {
-        CGWUCentralMessagesQueueItem {
-            command,
-            message,
-        }
+    pub fn new(command: CGWUCentralCommand, message: String) -> CGWUCentralMessagesQueueItem {
+        CGWUCentralMessagesQueueItem { command, message }
     }
 }
 
 pub struct CGWUCentralMessagesQueueManager {
-    queue: Arc<RwLock<HashMap<String, Arc<RwLock<VecDeque<CGWUCentralMessagesQueueItem>>>>>>,
+    queue: Arc<RwLock<HashMap<String, Arc<RwLock<CGWUCentralMessagesQueue>>>>>,
+    disconnected_devices: Arc<RwLock<HashMap<String, ()>>>,
 }
 
 const MESSAGE_QUEUE_REBOOT_MSG_INDEX: usize = 0;
 const MESSAGE_QUEUE_CONFIGURE_MSG_INDEX: usize = 1;
 const MESSAGE_QUEUE_OTHER_MSG_INDEX: usize = 2;
 
+pub const TIMEOUT_MANAGER_DURATION: Duration = Duration::from_secs(10);
+pub const MESSAGE_TIMEOUT_DURATION: Duration = Duration::from_secs(300);
+
 lazy_static! {
     pub static ref CGW_MESSAGES_QUEUE: Arc<RwLock<CGWUCentralMessagesQueueManager>> =
         Arc::new(RwLock::new(CGWUCentralMessagesQueueManager {
             queue: Arc::new(RwLock::new(HashMap::<
                 String,
-                Arc<RwLock<VecDeque<CGWUCentralMessagesQueueItem>>>,
-            >::new(),))
+                Arc<RwLock<CGWUCentralMessagesQueue>>,
+            >::new(),)),
+            disconnected_devices: Arc::new(RwLock::new(HashMap::<String, ()>::new()))
         }));
 }
 
@@ -49,14 +116,15 @@ lazy_static! {
 impl CGWUCentralMessagesQueueManager {
     pub async fn create_device_messages_queue(&self, device_mac: &String) {
         if !self.check_messages_queue_exists(&device_mac).await {
-            let new_queue: Arc<RwLock<VecDeque<CGWUCentralMessagesQueueItem>>> =
-                Arc::new(RwLock::new(VecDeque::new()));
+            debug!("Create queue message for device: {}", device_mac);
+            let new_queue: Arc<RwLock<CGWUCentralMessagesQueue>> =
+                Arc::new(RwLock::new(CGWUCentralMessagesQueue::new()));
 
-            new_queue.write().await.insert(
+            new_queue.write().await.insert_item(
                 MESSAGE_QUEUE_REBOOT_MSG_INDEX,
                 CGWUCentralMessagesQueueItem::default(),
             );
-            new_queue.write().await.insert(
+            new_queue.write().await.insert_item(
                 MESSAGE_QUEUE_CONFIGURE_MSG_INDEX,
                 CGWUCentralMessagesQueueItem::default(),
             );
@@ -66,48 +134,84 @@ impl CGWUCentralMessagesQueueManager {
         }
     }
 
-    pub async fn delete_device_messages_queue(&mut self, device_mac: &String) {
-        if self.check_messages_queue_exists(device_mac).await {
-            let mut write_lock = self.queue.write().await;
-            write_lock.remove(device_mac);
-        } else {
-            error!(
-                "Trying to delete message queue for unexisting device: {}",
-                device_mac
-            );
+    pub async fn delete_device_messages_queue(&self, device_mac: &String) {
+        let mut write_lock = self.queue.write().await;
+        debug!("Remove queue message for device: {}", device_mac);
+
+        match write_lock.remove(device_mac) {
+            Some(_) => {}
+            None => {
+                error!(
+                    "Trying to delete message queue for unexisting device: {}",
+                    device_mac
+                );
+            }
         }
+    }
+
+    pub async fn clear_device_message_queue(&self, device_mac: &String) {
+        debug!("Flush device {} queue due to timeout!", device_mac);
+        let container_lock = self.queue.read().await;
+        let mut device_msg_queue = container_lock.get(device_mac).unwrap().write().await;
+        device_msg_queue
+            .queue
+            .retain_mut(
+                |item: &mut CGWUCentralMessagesQueueItem| match item.command.cmd_type {
+                    CGWUCentralCommandType::Reboot
+                    | CGWUCentralCommandType::Configure
+                    | CGWUCentralCommandType::None => {
+                        *item = CGWUCentralMessagesQueueItem::default();
+                        true
+                    }
+                    _ => false,
+                },
+            );
     }
 
     pub async fn push_device_message(
         &self,
-        device_mac: &String,
-        value: &CGWUCentralMessagesQueueItem,
+        device_mac: String,
+        value: CGWUCentralMessagesQueueItem,
     ) {
         // 1. Get current message type
         let new_cmd_type: CGWUCentralCommandType = value.command.cmd_type.clone();
 
-        // 2. Create new message queue for device with MAC if it doesn't exist
-        self.create_device_messages_queue(device_mac).await;
-
-        // 3. Message queue for device exist -> get mutable ref
+        // 2. Message queue for device exist -> get mutable ref
+        self.create_device_messages_queue(&device_mac).await;
         let container_lock = self.queue.read().await;
-        let mut device_msg_queue = container_lock.get(device_mac).unwrap().write().await;
+        let mut device_msg_queue = container_lock.get(&device_mac).unwrap().write().await;
+        let queue_state = device_msg_queue.get_state();
 
-        match new_cmd_type {
-            // 3. If new message type == Reboot then replace message under reserved index
-            CGWUCentralCommandType::Reboot => {
-                device_msg_queue.remove(MESSAGE_QUEUE_REBOOT_MSG_INDEX);
-                device_msg_queue.insert(MESSAGE_QUEUE_REBOOT_MSG_INDEX, value.clone());
-            }
+        debug!(
+            "Push message for device: {}, queue state {:?}, command type {:?}",
+            device_mac, queue_state, new_cmd_type
+        );
 
-            // 4. If new message type == Configure then replace message under reserved index
-            CGWUCentralCommandType::Configure => {
-                device_msg_queue.remove(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX);
-                device_msg_queue.insert(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX, value.clone());
+        // Check Queue Message state
+        match queue_state {
+            CGWUCentralMessagesQueueState::RxTx | CGWUCentralMessagesQueueState::Rx => {
+                match new_cmd_type {
+                    // 3. If new message type == Reboot then replace message under reserved index
+                    CGWUCentralCommandType::Reboot => {
+                        device_msg_queue.remove_item(MESSAGE_QUEUE_REBOOT_MSG_INDEX);
+                        device_msg_queue.insert_item(MESSAGE_QUEUE_REBOOT_MSG_INDEX, value);
+                    }
+                    // 4. If new message type == Configure then replace message under reserved index
+                    CGWUCentralCommandType::Configure => {
+                        device_msg_queue.remove_item(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX);
+                        device_msg_queue.insert_item(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX, value);
+                    }
+                    // 5. If new message type == Other then push it back to queue
+                    _ => {
+                        device_msg_queue.push_back_item(value);
+                    }
+                }
             }
-            // 5. If new message type == Other then push it back to queue
-            _ => {
-                device_msg_queue.push_back(value.clone());
+            CGWUCentralMessagesQueueState::Discard => {
+                debug!(
+                    "Device {} queue is in discard state - drop request {}",
+                    device_mac, value.command.id
+                );
             }
         }
     }
@@ -129,11 +233,11 @@ impl CGWUCentralMessagesQueueManager {
         if self.check_messages_queue_exists(device_mac).await {
             let container_lock = self.queue.read().await;
             let device_msg_queue = container_lock.get(device_mac).unwrap().read().await;
-            queue_size = device_msg_queue.len();
+            queue_size = device_msg_queue.queue_len();
 
             let default_msg = CGWUCentralCommand::default();
             if device_msg_queue
-                .get(MESSAGE_QUEUE_REBOOT_MSG_INDEX)
+                .get_item(MESSAGE_QUEUE_REBOOT_MSG_INDEX)
                 .unwrap()
                 .command
                 == default_msg
@@ -141,7 +245,7 @@ impl CGWUCentralMessagesQueueManager {
                 queue_size -= 1;
             }
             if device_msg_queue
-                .get(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX)
+                .get_item(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX)
                 .unwrap()
                 .command
                 == default_msg
@@ -151,6 +255,31 @@ impl CGWUCentralMessagesQueueManager {
         }
 
         queue_size
+    }
+
+    pub async fn set_device_last_req_info(
+        &self,
+        device_mac: &String,
+        req_id: u64,
+        req_timeout: Duration,
+    ) {
+        let container_lock = self.queue.read().await;
+        let mut device_msg_queue = container_lock.get(device_mac).unwrap().write().await;
+
+        device_msg_queue.set_last_req_id(req_id);
+        device_msg_queue.set_last_req_timeout(req_timeout);
+    }
+
+    pub async fn get_device_last_request_id(&self, device_mac: &String) -> u64 {
+        let container_lock = self.queue.read().await;
+        let device_msg_queue = container_lock.get(device_mac).unwrap().read().await;
+
+        debug!(
+            "Last request id for device {}: {}",
+            device_mac,
+            device_msg_queue.get_last_req_id()
+        );
+        device_msg_queue.get_last_req_id()
     }
 
     // Dequeue messages accoring to priority:
@@ -171,34 +300,123 @@ impl CGWUCentralMessagesQueueManager {
 
         let mut device_msg_queue = container_lock.get(device_mac).unwrap().write().await;
         let reboot_msg = device_msg_queue
-            .get(MESSAGE_QUEUE_REBOOT_MSG_INDEX)
+            .get_item(MESSAGE_QUEUE_REBOOT_MSG_INDEX)
             .unwrap()
             .clone();
         let configure_msg = device_msg_queue
-            .get(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX)
+            .get_item(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX)
             .unwrap()
             .clone();
 
         if reboot_msg.command != default_msg {
             ret_msg = reboot_msg;
-            device_msg_queue.remove(MESSAGE_QUEUE_REBOOT_MSG_INDEX);
-            device_msg_queue.insert(
+            device_msg_queue.remove_item(MESSAGE_QUEUE_REBOOT_MSG_INDEX);
+            device_msg_queue.insert_item(
                 MESSAGE_QUEUE_REBOOT_MSG_INDEX,
                 CGWUCentralMessagesQueueItem::default(),
             );
         } else if configure_msg.command != default_msg {
             ret_msg = configure_msg;
-            device_msg_queue.remove(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX);
-            device_msg_queue.insert(
+            device_msg_queue.remove_item(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX);
+            device_msg_queue.insert_item(
                 MESSAGE_QUEUE_CONFIGURE_MSG_INDEX,
                 CGWUCentralMessagesQueueItem::default(),
             );
         } else {
             ret_msg = device_msg_queue
-                .remove(MESSAGE_QUEUE_OTHER_MSG_INDEX)
+                .remove_item(MESSAGE_QUEUE_OTHER_MSG_INDEX)
                 .unwrap();
         }
 
         Some(ret_msg)
+    }
+
+    pub async fn get_device_queue_state(
+        &self,
+        device_mac: &String,
+    ) -> CGWUCentralMessagesQueueState {
+        let container_lock = self.queue.read().await;
+        let device_msg_queue = container_lock.get(device_mac).unwrap().read().await;
+
+        device_msg_queue.get_state()
+    }
+
+    pub async fn set_device_queue_state(
+        &self,
+        device_mac: &String,
+        state: CGWUCentralMessagesQueueState,
+    ) {
+        let container_lock = self.queue.read().await;
+        let mut device_msg_queue = container_lock.get(device_mac).unwrap().write().await;
+
+        device_msg_queue.set_state(state);
+    }
+
+    pub async fn device_disconnected(&self, device_mac: &String) {
+        let mut disconnected_lock = self.disconnected_devices.write().await;
+        disconnected_lock.insert(device_mac.clone(), ());
+    }
+
+    pub async fn device_connected(&self, device_mac: &String) {
+        self.remove_disconnected_device_timeout(device_mac).await;
+    }
+
+    async fn remove_disconnected_device_timeout(&self, device_mac: &String) {
+        let mut disconnected_lock = self.disconnected_devices.write().await;
+        disconnected_lock.remove(device_mac);
+    }
+
+    pub async fn device_request_tick(&self, device_mac: &String, elapsed: Duration) -> bool {
+        let mut expired: bool = false;
+        let container_read_lock = self.queue.read().await;
+        let mut device_queue = container_read_lock.get(device_mac).unwrap().write().await;
+
+        device_queue.last_req_timeout = device_queue.last_req_timeout.saturating_sub(elapsed);
+
+        if device_queue.last_req_timeout == Duration::ZERO {
+            expired = true;
+        }
+
+        expired
+    }
+
+    async fn iterate_over_disconnected_devices(&self) {
+        let container_read_lock = self.disconnected_devices.read().await;
+        let mut devices_to_flush: Vec<String> = Vec::<String>::new();
+
+        // 1. Check if disconnected device message queue is empty
+        // If not empty - just do tick
+        // Else - disconnected device and it queue should be removed
+        for (device_mac, _) in container_read_lock.iter() {
+            if self.get_device_messages_queue_len(device_mac).await > 0 {
+                // If device request is timed out - device and it queue should be removed
+                if self
+                    .device_request_tick(device_mac, TIMEOUT_MANAGER_DURATION)
+                    .await
+                {
+                    devices_to_flush.push(device_mac.clone());
+                }
+            } else {
+                devices_to_flush.push(device_mac.clone());
+            }
+        }
+
+        // 2. Remove disconnected device and it queue
+        let mut container_write_lock = self.disconnected_devices.write().await;
+        for device_mac in devices_to_flush.iter() {
+            self.delete_device_messages_queue(device_mac).await;
+            container_write_lock.remove(device_mac);
+        }
+    }
+
+    pub async fn start_queue_timeout_manager(&self) {
+        loop {
+            // Wait for 10 seconds
+            time::sleep(TIMEOUT_MANAGER_DURATION).await;
+
+            // iterate over disconnected devices
+            let queue_lock = CGW_MESSAGES_QUEUE.read().await;
+            queue_lock.iterate_over_disconnected_devices().await;
+        }
     }
 }

--- a/src/cgw_ucentral_messages_queue_manager.rs
+++ b/src/cgw_ucentral_messages_queue_manager.rs
@@ -1,0 +1,204 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::cgw_ucentral_parser::{CGWUCentralCommand, CGWUCentralCommandType};
+
+#[derive(Clone, Debug, Default)]
+pub struct CGWUCentralMessagesQueueItem {
+    pub command: CGWUCentralCommand,
+    pub message: String,
+}
+
+impl CGWUCentralMessagesQueueItem {
+    pub fn new(
+        command: CGWUCentralCommand,
+        message: String,
+    ) -> CGWUCentralMessagesQueueItem {
+        CGWUCentralMessagesQueueItem {
+            command,
+            message,
+        }
+    }
+}
+
+pub struct CGWUCentralMessagesQueueManager {
+    queue: Arc<RwLock<HashMap<String, Arc<RwLock<VecDeque<CGWUCentralMessagesQueueItem>>>>>>,
+}
+
+const MESSAGE_QUEUE_REBOOT_MSG_INDEX: usize = 0;
+const MESSAGE_QUEUE_CONFIGURE_MSG_INDEX: usize = 1;
+const MESSAGE_QUEUE_OTHER_MSG_INDEX: usize = 2;
+
+lazy_static! {
+    pub static ref CGW_MESSAGES_QUEUE: Arc<RwLock<CGWUCentralMessagesQueueManager>> =
+        Arc::new(RwLock::new(CGWUCentralMessagesQueueManager {
+            queue: Arc::new(RwLock::new(HashMap::<
+                String,
+                Arc<RwLock<VecDeque<CGWUCentralMessagesQueueItem>>>,
+            >::new(),))
+        }));
+}
+
+// The HashMap is used to store requests for device
+// The HashMap key - device MAC, value - VecDeque as message queue
+// There are two reserved items under index '0' and '1'
+// Index '0' - store 'reboot' command
+// Index '1' - store 'configure' command
+// All rest used to store other messages types
+impl CGWUCentralMessagesQueueManager {
+    pub async fn create_device_messages_queue(&self, device_mac: &String) {
+        if !self.check_messages_queue_exists(&device_mac).await {
+            let new_queue: Arc<RwLock<VecDeque<CGWUCentralMessagesQueueItem>>> =
+                Arc::new(RwLock::new(VecDeque::new()));
+
+            new_queue.write().await.insert(
+                MESSAGE_QUEUE_REBOOT_MSG_INDEX,
+                CGWUCentralMessagesQueueItem::default(),
+            );
+            new_queue.write().await.insert(
+                MESSAGE_QUEUE_CONFIGURE_MSG_INDEX,
+                CGWUCentralMessagesQueueItem::default(),
+            );
+
+            let mut write_lock = self.queue.write().await;
+            write_lock.insert(device_mac.clone(), new_queue);
+        }
+    }
+
+    pub async fn delete_device_messages_queue(&mut self, device_mac: &String) {
+        if self.check_messages_queue_exists(device_mac).await {
+            let mut write_lock = self.queue.write().await;
+            write_lock.remove(device_mac);
+        } else {
+            error!(
+                "Trying to delete message queue for unexisting device: {}",
+                device_mac
+            );
+        }
+    }
+
+    pub async fn push_device_message(
+        &self,
+        device_mac: &String,
+        value: &CGWUCentralMessagesQueueItem,
+    ) {
+        // 1. Get current message type
+        let new_cmd_type: CGWUCentralCommandType = value.command.cmd_type.clone();
+
+        // 2. Create new message queue for device with MAC if it doesn't exist
+        self.create_device_messages_queue(device_mac).await;
+
+        // 3. Message queue for device exist -> get mutable ref
+        let container_lock = self.queue.read().await;
+        let mut device_msg_queue = container_lock.get(device_mac).unwrap().write().await;
+
+        match new_cmd_type {
+            // 3. If new message type == Reboot then replace message under reserved index
+            CGWUCentralCommandType::Reboot => {
+                device_msg_queue.remove(MESSAGE_QUEUE_REBOOT_MSG_INDEX);
+                device_msg_queue.insert(MESSAGE_QUEUE_REBOOT_MSG_INDEX, value.clone());
+            }
+
+            // 4. If new message type == Configure then replace message under reserved index
+            CGWUCentralCommandType::Configure => {
+                device_msg_queue.remove(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX);
+                device_msg_queue.insert(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX, value.clone());
+            }
+            // 5. If new message type == Other then push it back to queue
+            _ => {
+                device_msg_queue.push_back(value.clone());
+            }
+        }
+    }
+
+    pub async fn check_messages_queue_exists(&self, device_mac: &String) -> bool {
+        let exist: bool;
+        let container_lock = self.queue.read().await;
+        match container_lock.get(device_mac) {
+            Some(_) => exist = true,
+            None => exist = false,
+        }
+
+        exist
+    }
+
+    pub async fn get_device_messages_queue_len(&self, device_mac: &String) -> usize {
+        let mut queue_size: usize = 0;
+
+        if self.check_messages_queue_exists(device_mac).await {
+            let container_lock = self.queue.read().await;
+            let device_msg_queue = container_lock.get(device_mac).unwrap().read().await;
+            queue_size = device_msg_queue.len();
+
+            let default_msg = CGWUCentralCommand::default();
+            if device_msg_queue
+                .get(MESSAGE_QUEUE_REBOOT_MSG_INDEX)
+                .unwrap()
+                .command
+                == default_msg
+            {
+                queue_size -= 1;
+            }
+            if device_msg_queue
+                .get(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX)
+                .unwrap()
+                .command
+                == default_msg
+            {
+                queue_size -= 1;
+            }
+        }
+
+        queue_size
+    }
+
+    // Dequeue messages accoring to priority:
+    // 1. Check if reboot message exist in queue and return it if true
+    // 2. Check if configure message exist in queue and return it if true
+    // 3. Remove other message from qeueu and return it
+    pub async fn dequeue_device_message(
+        &self,
+        device_mac: &String,
+    ) -> Option<CGWUCentralMessagesQueueItem> {
+        let ret_msg: CGWUCentralMessagesQueueItem;
+        let default_msg = CGWUCentralCommand::default();
+        let container_lock = self.queue.read().await;
+
+        if self.get_device_messages_queue_len(device_mac).await == 0 {
+            return None;
+        }
+
+        let mut device_msg_queue = container_lock.get(device_mac).unwrap().write().await;
+        let reboot_msg = device_msg_queue
+            .get(MESSAGE_QUEUE_REBOOT_MSG_INDEX)
+            .unwrap()
+            .clone();
+        let configure_msg = device_msg_queue
+            .get(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX)
+            .unwrap()
+            .clone();
+
+        if reboot_msg.command != default_msg {
+            ret_msg = reboot_msg;
+            device_msg_queue.remove(MESSAGE_QUEUE_REBOOT_MSG_INDEX);
+            device_msg_queue.insert(
+                MESSAGE_QUEUE_REBOOT_MSG_INDEX,
+                CGWUCentralMessagesQueueItem::default(),
+            );
+        } else if configure_msg.command != default_msg {
+            ret_msg = configure_msg;
+            device_msg_queue.remove(MESSAGE_QUEUE_CONFIGURE_MSG_INDEX);
+            device_msg_queue.insert(
+                MESSAGE_QUEUE_CONFIGURE_MSG_INDEX,
+                CGWUCentralMessagesQueueItem::default(),
+            );
+        } else {
+            ret_msg = device_msg_queue
+                .remove(MESSAGE_QUEUE_OTHER_MSG_INDEX)
+                .unwrap();
+        }
+
+        Some(ret_msg)
+    }
+}

--- a/src/cgw_ucentral_parser.rs
+++ b/src/cgw_ucentral_parser.rs
@@ -13,14 +13,14 @@ use crate::{
 
 pub type CGWUcentralJRPCMessage = Map<String, Value>;
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CGWUCentralEventLog {
     pub serial: String,
     pub log: String,
     pub severity: i64,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CGWUCentralEventConnectParamsCaps {
     pub compatible: String,
     pub model: String,
@@ -28,7 +28,7 @@ pub struct CGWUCentralEventConnectParamsCaps {
     pub label_macaddr: String,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CGWUCentralEventConnect {
     pub serial: String,
     pub firmware: String,
@@ -36,7 +36,7 @@ pub struct CGWUCentralEventConnect {
     pub capabilities: CGWUCentralEventConnectParamsCaps,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CGWUCentralEventStateLLDPDataLinks {
     pub local_port: String,
     #[serde(skip)]
@@ -45,7 +45,7 @@ pub struct CGWUCentralEventStateLLDPDataLinks {
     pub is_downstream: bool,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CGWUCentralEventStateLLDPData {
     // Parsed State LLDP data:
     // mac address of the device reporting the LLDP data
@@ -57,17 +57,17 @@ pub struct CGWUCentralEventStateLLDPData {
     pub links: Vec<CGWUCentralEventStateLLDPDataLinks>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CGWUCentralEventState {
     pub lldp_data: CGWUCentralEventStateLLDPData,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CGWUCentralEventReply {
     pub id: u64,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub enum CGWUCentralEventType {
     Connect(CGWUCentralEventConnect),
     State(CGWUCentralEventState),

--- a/src/cgw_ucentral_parser.rs
+++ b/src/cgw_ucentral_parser.rs
@@ -113,7 +113,7 @@ pub struct CGWDeviceChangedData {
     pub changes: Vec<CGWDeviceChange>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub enum CGWUCentralCommandType {
     Configure,
     Reboot,
@@ -132,6 +132,8 @@ pub enum CGWUCentralCommandType {
     Script,
     CertUpdate,
     Transfer,
+    #[default]
+    None,
 }
 
 impl FromStr for CGWUCentralCommandType {
@@ -156,12 +158,13 @@ impl FromStr for CGWUCentralCommandType {
             "script" => Ok(CGWUCentralCommandType::Script),
             "certupdate" => Ok(CGWUCentralCommandType::CertUpdate),
             "transfer" => Ok(CGWUCentralCommandType::Transfer),
+            "None" => Ok(CGWUCentralCommandType::None),
             _ => Err(()),
         }
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct CGWUCentralCommand {
     pub serial: String,
     pub cmd_type: CGWUCentralCommandType,
@@ -228,15 +231,9 @@ pub fn cgw_ucentral_parse_connect_event(
 }
 
 pub fn cgw_ucentral_parse_command_message(
-    message: Message,
+    message: &String,
 ) -> Result<CGWUCentralCommand, &'static str> {
-    let msg = if let Ok(s) = message.into_text() {
-        s
-    } else {
-        return Err("Message to string cast failed");
-    };
-
-    let map: CGWUcentralJRPCMessage = match serde_json::from_str(&msg) {
+    let map: CGWUcentralJRPCMessage = match serde_json::from_str(message) {
         Ok(m) => m,
         Err(e) => {
             error!("Failed to parse input json {e}");

--- a/src/cgw_ucentral_switch_parser.rs
+++ b/src/cgw_ucentral_switch_parser.rs
@@ -1,11 +1,9 @@
-use std::str::FromStr;
-
 use eui48::MacAddress;
 use serde_json::Value;
+use std::str::FromStr;
 
 use crate::cgw_ucentral_parser::{
-    CGWUCentralEvent, CGWUCentralEventConnect, CGWUCentralEventConnectParamsCaps,
-    CGWUCentralEventLog, CGWUCentralEventState, CGWUCentralEventStateLLDPData,
+    CGWUCentralEvent, CGWUCentralEventLog, CGWUCentralEventState, CGWUCentralEventStateLLDPData,
     CGWUCentralEventStateLLDPDataLinks, CGWUCentralEventType, CGWUcentralJRPCMessage,
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod cgw_ucentral_ap_parser;
 mod cgw_ucentral_parser;
 mod cgw_ucentral_switch_parser;
 mod cgw_ucentral_topology_map;
+mod cgw_ucentral_messages_queue_manager;
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
1) Added prioritized message queue
    - Reboot message has top priority - and should be processed first.
    - Configure message has second priority.
    - All other request has same priority and push to queue in received order.
    - Process only last received reboot or configure message.
 2) Add timeout manager
     - Timeout manager obtain disconnected device list.
     - On device disconnect - push mac to disconnected device list.
     - Run in background task to iterate over disconnected devices list.
     - Every 10 seconds check if disconnected device message queue is empty:
         - If yes - remove device message queue and remove device from disconnected device list.
         - If no - decrease device timeout.
     - If device timed out and was not reconnected - remove device message queue and device it self from disconnected devices list.
     - If device reconnected - remove it from disconnected devices list. 