### PR TITLE
Dev foreign infra mgmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ CGW utilizes gRPC to communicate with other CGW instances (referred to as Shards
 CGW uses Kafka as a main North-Bound API layer for communication with NB services. CnC topic is used for commands and requests handling, CnC_Res is used to send replies/results back (CGW reads CnC and writes into CnC_Res).
 ### Requirements
 It's required for the Kafka to have the following topics premade upon CGW launch:
+1. "CnC"     - Kafka consumer topic
+2. "CnC_Res" - Kafka producer topic
 ## PSQL
 Application utilizes relational DB (PSQL) to store registered Infrastructure Groups as well as registered Infrastructures.
 ### Requirements
@@ -33,13 +35,9 @@ FOREIGN KEY(infra_group_id) REFERENCES infrastructure_groups(id) ON DELETE CASCA
 ## Redis
 fast in-memory DB that CGW uses to store all needed runtime information (InfraGroup assigned CGW id, remote CGW info - IP, gRPC port etc)
 # Building
-Before building CGW you must put cert+key pair into the src folder, named *localhost.crt* and *localhost.key*.
-These steps are not part of the build, and crt+key pair should exist upon running the build command.
-Key and certificate will be used by the CGW internally to validate incoming WSS connections.
 ```console
 $ make all
 ```
-The output (CGW binaries) is then put into the ./output/bin directory.
 Two new docker images will be generated on host system:
 **openlan_cgw** - image that holds CGW application itself
 **cgw_build_env** - building enviroment docker image that is used for generating openlan_cgw
@@ -90,7 +88,7 @@ declare -x CGW_ID="1"
 declare -x CGW_KAFKA_IP="127.0.0.1"        # Kafka is located at the local host
 declare -x CGW_KAFKA_PORT="9092"
 declare -x CGW_LOG_LEVEL="debug"
-declare -x CGW_REDIS_DB_IP="172.0.0.1"     # Redis server can be found at the local host
+declare -x CGW_REDIS_DB_IP="127.0.0.1"     # Redis server can be found at the local host
 declare -x CGW_WSS_IP="0.0.0.0"            # Accept WSS connections at all interfaces / subnets
 declare -x CGW_WSS_PORT="15002"
 declare -x CGW_WSS_CAS="cas.pem"

--- a/src/cgw_nb_api_listener.rs
+++ b/src/cgw_nb_api_listener.rs
@@ -94,6 +94,22 @@ pub struct InfraGroupDeviceCapabilitiesChanged {
     pub changes: Vec<CGWDeviceChange>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct UnassignedInfraConnection {
+    pub r#type: &'static str,
+    pub infra_group_infra_device: MacAddress,
+    pub reporter_shard_id: i32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ForeignInfraConnection {
+    pub r#type: &'static str,
+    pub infra_group_id: i32,
+    pub infra_group_infra_device: MacAddress,
+    pub reporter_shard_id: i32,
+    pub group_owner_shard_id: i32,
+}
+
 pub fn cgw_construct_infra_group_create_response(
     infra_group_id: i32,
     infra_name: String,
@@ -223,6 +239,36 @@ pub fn cgw_construct_device_capabilities_changed_msg(
     };
 
     Ok(serde_json::to_string(&dev_cap_msg)?)
+}
+
+pub fn cgw_construct_unassigned_infra_connection_msg(
+    infra_group_infra_device: MacAddress,
+    reporter_shard_id: i32,
+) -> Result<String> {
+    let unassigned_infra_msg = UnassignedInfraConnection {
+        r#type: "unassigned_infra_connection",
+        infra_group_infra_device,
+        reporter_shard_id,
+    };
+
+    Ok(serde_json::to_string(&unassigned_infra_msg)?)
+}
+
+pub fn cgw_construct_foreign_infra_connection_msg(
+    infra_group_id: i32,
+    infra_group_infra_device: MacAddress,
+    reporter_shard_id: i32,
+    group_owner_shard_id: i32,
+) -> Result<String> {
+    let foreign_infra_msg = ForeignInfraConnection {
+        r#type: "foreign_infra_connection",
+        infra_group_id,
+        infra_group_infra_device,
+        reporter_shard_id,
+        group_owner_shard_id,
+    };
+
+    Ok(serde_json::to_string(&foreign_infra_msg)?)
 }
 
 struct CustomContext;


### PR DESCRIPTION
Send to NB detected foreign or unassigned infra connection
Kafka messages example:

1) Unassigned infra connection message
```json
{
  "timestamp": 1717595992490,
  "name": "record_data",
  "key": "2045",
  "value": "{\"type\":\"unassigned_infra_connection\",\"infra_group_infra_device\":90:3C:B3:6A:E3:59},\"reporter_shard_id\":\"0\"",
  "topic": "CnC_Res",
  "partition": 0,
  "offset": 16
}
```

2) Infra add response
```json
{
  "timestamp": 1717595992490,
  "name": "record_data",
  "key": "2045",
  "value": "{\"type\":\"foreign_infra_connection\",\"infra_group_id\":\"2023\",\"infra_group_infra_device\":90:3C:B3:6A:E3:59},\"reporter_shard_id\":\"0\",\"group_owner_shard_id\":\"1\"",
  "topic": "CnC_Res",
  "partition": 0,
  "offset": 16
}