### PR TITLE
Topo-map: Add FDB parser / handling

### DIFF
--- a/src/cgw_ucentral_parser.rs
+++ b/src/cgw_ucentral_parser.rs
@@ -49,9 +49,12 @@ pub struct CGWUCentralEventStateLinks {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub enum CGWUCentralEventStateClientsType {
+    // Timestamp
     Wired(i64),
-    // Ssid, Band
+    // Timestamp, Ssid, Band
     Wireless(i64, String, String),
+    // VID
+    FDBClient(u16),
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]


### PR DESCRIPTION
Implement basic FDB parser and FDB hosts topo-map
population.
This initial implementation does not care for
duplicates (replaces them) that could've been
detected in other (from AP, for example) state events. Duplicates are simply replaced in favor of new ones, e.g: AP reports <wired_client_1> - get's added to topo map; SW reports <wired_client_1> in fdb table - the new event 'replaces' old information in favor of SW's.
Whenever AP reports same mac once again, it will get replaced again.

The observed flickering and wired client migration from SW to AP and vice-versa should be fixed by a much more in-deph logic implemented: unknown infra management, more in-depth uplink port data ignoring and a proper duplicate MAC handling procedure.

All this is not being done in scope of this commit.