### PR TITLE
Cleanup Redis shard id record on SIGTERM, SIGINT, SIGHUP

### DIFF
--- a/src/cgw_connection_processor.rs
+++ b/src/cgw_connection_processor.rs
@@ -256,8 +256,20 @@ impl CGWConnectionProcessor {
                             topo_map.process_state_message(&device_type, evt).await;
                             topo_map.debug_dump_map().await;
                         } else if let CGWUCentralEventType::Reply(content) = evt.evt_type {
-                            assert_eq!(*fsm_state, CGWUCentralMessageProcessorState::ResultPending);
-                            assert_eq!(content.id, pending_req_id);
+                            if *fsm_state != CGWUCentralMessageProcessorState::ResultPending {
+                                error!(
+                                    "Unexpected FSM {:?} state! Expected: ResultPending",
+                                    *fsm_state
+                                );
+                            }
+
+                            if content.id != pending_req_id {
+                                error!(
+                                    "Pending request ID {} is not equal received reply ID {}!",
+                                    pending_req_id, content.id
+                                );
+                            }
+
                             *fsm_state = CGWUCentralMessageProcessorState::Idle;
                             debug!("Got reply event for pending request id: {}", pending_req_id);
                         } else if let CGWUCentralEventType::RealtimeEvent(_) = evt.evt_type {

--- a/src/cgw_connection_server.rs
+++ b/src/cgw_connection_server.rs
@@ -1187,6 +1187,10 @@ impl CGWConnectionServer {
                 .await;
         });
     }
+
+    pub async fn cleanup_redis(&self) {
+        self.cgw_remote_discovery.cleanup_redis().await;
+    }
 }
 
 #[cfg(test)]

--- a/src/cgw_db_accessor.rs
+++ b/src/cgw_db_accessor.rs
@@ -68,7 +68,7 @@ impl CGWDBAccessor {
 
         tokio::spawn(async move {
             if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
+                error!("connection error: {}", e);
             }
         });
 

--- a/src/cgw_nb_api_listener.rs
+++ b/src/cgw_nb_api_listener.rs
@@ -482,7 +482,7 @@ impl CGWNBApiClient {
         );
 
         if let Err((e, _)) = produce_future.await {
-            println!("Error: {:?}", e)
+            error!("{:?}", e)
         }
     }
 

--- a/src/cgw_remote_discovery.rs
+++ b/src/cgw_remote_discovery.rs
@@ -764,4 +764,16 @@ impl CGWRemoteDiscovery {
 
         Ok(0u32)
     }
+
+    pub async fn cleanup_redis(&self) {
+        debug!("Remove from Redis shard id {}", self.local_shard_id);
+        // We are on de-init stage - ignore any errors on Redis clean-up
+        let _ = self
+            .redis_client
+            .send::<i32>(resp_array![
+                "DEL",
+                format!("{REDIS_KEY_SHARD_ID_PREFIX}{}", self.local_shard_id)
+            ])
+            .await;
+    }
 }


### PR DESCRIPTION
1) Handle SIGHUP, SIGINT, SIGTERM
2) Clean up Redis shard id record on received signals mentioned above
3) Init logger at the beginnig of main task
4) Use debug!, error! macros instead of println!/eprintln!
5) Remove assert macro - leads to panic