### PR TITLE
Add health endpoints to metrics

### DIFF
--- a/src/cgw_errors.rs
+++ b/src/cgw_errors.rs
@@ -9,8 +9,6 @@ pub enum Error {
 
     ConnectionServer(&'static str),
 
-    Metrics(&'static str),
-
     DbAccessor(&'static str),
 
     RemoteDiscovery(&'static str),


### PR DESCRIPTION
 - Add dedicated /health endpoint to metrics engine/server, that shows the status of the CGW application (are all components ready to work etc);
 - For KAFKA we rely, as of now, on the post-rebalancing callback: if we've been assigned some partition, means KAFKA is OK;
 - For DB component no <table is missing>, <tabli is invalid> are tacked: these realtime error detection capabilities should be implemented in other set of changes;
 - For REDIS health is deduced on the fact whether we can read/write, as the connection itself is a <lazy> one;
 - This Commit also changes error reporting and logging logic a bit: explicit errors are printed upon detection, and in case of faulty /failed connections to REDIS, KAFKA, DB they will be explicitly prompted, compared to previous silent unhandled behavior (this happens, because in case of any connectivity issue current codebase unwinds stack / clears on-stack allocced objects, which in their turn nuke the RUNTIMES in a context, where they should not be doing that - to be refactored - hence, all the errors reported to the top-caller were silently dropped, as no actual <return error value> was happening