### PR TITLE
CGW: Fix deadlock occuring in msg queue

### DIFF
--- a/src/cgw_remote_discovery.rs
+++ b/src/cgw_remote_discovery.rs
@@ -627,8 +627,6 @@ impl CGWRemoteDiscovery {
             device_cache.del_device(key);
         }
 
-        device_cache.dump_devices_cache();
-
         Ok(())
     }
 
@@ -681,7 +679,6 @@ impl CGWRemoteDiscovery {
                                 ),
                             );
                         }
-                        devices_cache.dump_devices_cache();
                     }
                 }
                 Err(_) => {
@@ -734,7 +731,6 @@ impl CGWRemoteDiscovery {
                             } else {
                                 devices_cache.del_device(&device_mac);
                             }
-                            devices_cache.dump_devices_cache();
                         }
                     }
                 }

--- a/src/cgw_ucentral_messages_queue_manager.rs
+++ b/src/cgw_ucentral_messages_queue_manager.rs
@@ -300,11 +300,12 @@ impl CGWUCentralMessagesQueueManager {
     ) -> Option<CGWUCentralMessagesQueueItem> {
         let ret_msg: CGWUCentralMessagesQueueItem;
         let default_msg = CGWUCentralCommand::default();
-        let container_lock = self.queue.read().await;
 
         if self.get_device_messages_queue_len(device_mac).await == 0 {
             return None;
         }
+
+        let container_lock = self.queue.read().await;
 
         let mut device_msg_queue = container_lock.get(device_mac)?.write().await;
         let reboot_msg = device_msg_queue

--- a/src/main.rs
+++ b/src/main.rs
@@ -567,7 +567,7 @@ async fn server_loop(app_core: Arc<AppCore>) -> Result<()> {
                     }
                 };
 
-                info!("Started WSS server.");
+                info!("ACK conn: {}", conn_idx);
 
                 app_core_clone.conn_ack_runtime_handle.spawn(async move {
                     cgw_server_clone


### PR DESCRIPTION
Double-read-lock acquisition forced a deadlock in some stressfull specific scenarios, where the same lock get's aquired for <write> later on.

Isolate required <read> locks in their own contextes, as well as make sure we alter msg queue only <after> ACK is received from conn_server;

Also remove some nasty logs (cache+topo map), as well as misleading <Started wss server> print