### PR TITLE
CGW: Allow disabling topomap handling through env var

### DIFF
--- a/run_cgw.sh
+++ b/run_cgw.sh
@@ -111,6 +111,7 @@ docker run \
 	-e CGW_DB_PASSWORD         \
 	-e CGW_REDIS_HOST          \
 	-e CGW_REDIS_PORT          \
+	-e CGW_FEATURE_TOPOMAP_DISABLE \
 	-e CGW_METRICS_PORT        \
 	-e CGW_ALLOW_CERT_MISMATCH \
 	-d -t --network=host --name $2 $1 ucentral-cgw


### PR DESCRIPTION
To disable the feature, the CGW_FEATURE_TOPOMAP_DISABLE should be exported (value doesn't matter);
To enabled it back, the ENV var CGW_FEATURE_TOPOMAP_DISABLE should be unset:
$ unset CGW_FEATURE_TOPOMAP_DISABLE