### PR TITLE
Do not send device capabilities change message to NB for unassigned …

### DIFF
--- a/src/cgw_connection_server.rs
+++ b/src/cgw_connection_server.rs
@@ -1535,6 +1535,33 @@ impl CGWConnectionServer {
 
                                 debug!("Detected foreign infra {} connection. Group: {}, Group Shard Owner: {}", device_mac.to_hex_string(), group_id, group_owner_id);
                             }
+
+                            let changes =
+                                cgw_detect_device_chages(&device.get_device_capabilities(), &caps);
+                            match changes {
+                                Some(diff) => {
+                                    if let Ok(resp) = cgw_construct_device_capabilities_changed_msg(
+                                        device_mac,
+                                        device.get_device_group_id(),
+                                        &diff,
+                                    ) {
+                                        self.enqueue_mbox_message_from_cgw_to_nb_api(
+                                            device.get_device_group_id(),
+                                            resp,
+                                        );
+                                    } else {
+                                        error!(
+                                        "Failed to construct device_capabilities_changed message!"
+                                    );
+                                    }
+                                }
+                                None => {
+                                    debug!(
+                                        "Capabilities for device: {} was not changed",
+                                        device_mac.to_hex_string()
+                                    )
+                                }
+                            }
                         } else {
                             if let Ok(resp) = cgw_construct_unassigned_infra_connection_msg(
                                 device_mac,
@@ -1551,32 +1578,6 @@ impl CGWConnectionServer {
                             );
                         }
 
-                        let changes =
-                            cgw_detect_device_chages(&device.get_device_capabilities(), &caps);
-                        match changes {
-                            Some(diff) => {
-                                if let Ok(resp) = cgw_construct_device_capabilities_changed_msg(
-                                    device_mac,
-                                    device.get_device_group_id(),
-                                    &diff,
-                                ) {
-                                    self.enqueue_mbox_message_from_cgw_to_nb_api(
-                                        device.get_device_group_id(),
-                                        resp,
-                                    );
-                                } else {
-                                    error!(
-                                        "Failed to construct device_capabilities_changed message!"
-                                    );
-                                }
-                            }
-                            None => {
-                                debug!(
-                                    "Capabilities for device: {} was not changed",
-                                    device_mac.to_hex_string()
-                                )
-                            }
-                        }
                         device.update_device_capabilities(&caps);
                         match serde_json::to_string(device) {
                             Ok(device_json) => {
@@ -1593,28 +1594,6 @@ impl CGWConnectionServer {
                             }
                         }
                     } else {
-                        let default_caps: CGWDeviceCapabilities = Default::default();
-                        let changes = cgw_detect_device_chages(&default_caps, &caps);
-                        match changes {
-                            Some(diff) => {
-                                if let Ok(resp) = cgw_construct_device_capabilities_changed_msg(
-                                    device_mac, 0, &diff,
-                                ) {
-                                    self.enqueue_mbox_message_from_cgw_to_nb_api(0, resp);
-                                } else {
-                                    error!(
-                                        "Failed to construct device_capabilities_changed message!"
-                                    );
-                                }
-                            }
-                            None => {
-                                debug!(
-                                    "Capabilities for device: {} was not changed",
-                                    device_mac.to_hex_string()
-                                )
-                            }
-                        }
-
                         let device: CGWDevice = CGWDevice::new(
                             device_type,
                             CGWDeviceState::CGWDeviceConnected,

--- a/src/cgw_remote_discovery.rs
+++ b/src/cgw_remote_discovery.rs
@@ -880,7 +880,7 @@ impl CGWRemoteDiscovery {
         gid: i32,
         infras: Vec<MacAddress>,
         cache: Arc<RwLock<CGWDevicesCache>>,
-    ) -> Result<()> {
+    ) -> Result<Vec<MacAddress>> {
         // TODO: assign list to shards; currently - only created bulk, no assignment
         let mut futures = Vec::with_capacity(infras.len());
         // Results store vec of MACs we failed to add
@@ -906,6 +906,7 @@ impl CGWRemoteDiscovery {
             return Err(Error::RemoteDiscoveryFailedInfras(infras));
         }
 
+        let mut success_infras: Vec<MacAddress> = Vec::with_capacity(futures.len());
         let mut failed_infras: Vec<MacAddress> = Vec::with_capacity(futures.len());
         for x in infras.iter() {
             let db_accessor_clone = self.db_accessor.clone();
@@ -974,6 +975,7 @@ impl CGWRemoteDiscovery {
                                 }
                             }
                         }
+                        success_infras.push(device_mac);
                         assigned_infras_num += 1;
                     }
                 }
@@ -995,7 +997,7 @@ impl CGWRemoteDiscovery {
             return Err(Error::RemoteDiscoveryFailedInfras(failed_infras));
         }
 
-        Ok(())
+        Ok(success_infras)
     }
 
     pub async fn destroy_ifras_list(


### PR DESCRIPTION
1) Skip sending device capabilities change message to NB for unassigned infras
2) If CGW receive "infra_add" message for connected unassigned infra - send capabilities change message to NB.
3) For "infras_add" request - update NB on device GID change only for successfully installed infras.