### PR TITLE
Update NB APIs: Client join/leave/migrate

### DIFF
--- a/api/cnc_res_api.yaml
+++ b/api/cnc_res_api.yaml
@@ -359,8 +359,7 @@ infra_request_result:
     type: string
     format: uuid
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string

--- a/api/cnc_res_api.yaml
+++ b/api/cnc_res_api.yaml
@@ -156,7 +156,7 @@ infrastructure_group_infras_add_response:
     items:
       type: string
   kafka_partition_key:
-    description: CGW can return a special string value - kafka partition key,
+    description: MANDATORY field. CGW can return a special string value - kafka partition key,
       that can be used by generating consecutive cnc request,
       that will result in direct addressing of the shard that replied
       to the original request.
@@ -231,7 +231,7 @@ infrastructure_group_infras_del_response:
     items:
       type: string
   kafka_partition_key:
-    description: CGW can return a special string value - kafka partition key,
+    description: MANDATORY field. CGW can return a special string value - kafka partition key,
       that can be used by generating consecutive cnc request,
       that will result in direct addressing of the shard that replied
       to the original request.
@@ -298,7 +298,7 @@ infrastructure_group_infra_message_enqueue_response:
       Empty otherwise.
     type: string
   kafka_partition_key:
-    description: CGW can return a special string value - kafka partition key,
+    description: MANDATORY field. CGW can return a special string value - kafka partition key,
       that can be used by generating consecutive cnc request,
       that will result in direct addressing of the shard that replied
       to the original request.
@@ -360,8 +360,9 @@ infra_request_result:
     format: uuid
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
   success:
     type: boolean

--- a/api/events.yaml
+++ b/api/events.yaml
@@ -14,24 +14,30 @@ infra_join:
       ID of the shard that handled request and generated this response.
     type: integer
   infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
     description:
+      MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   infra_public_ip:
     description:
+      MANDATORY field.
       Peer address of the connected infra, as seen on the socket level
       of the CGW.
     type: string
   connect_message_payload:
     description:
+      MANDATORY field.
       Payload of infra CONNECT message
     type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
   timestamp:
     description: MANDATORY field.
@@ -52,15 +58,19 @@ infra_leave:
       ID of the shard that handled request and generated this response.
     type: integer
   infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
     description:
+      MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
   timestamp:
     description: MANDATORY field.
@@ -82,19 +92,23 @@ unassigned_infra_join:
     type: integer
   group_owner_shard_id:
     description:
+      MANDATORY field.
       ID of the shard that is the actual owner of the infra group.
     type: integer
   infra_group_infra:
     description:
+      MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   infra_public_ip:
     description:
+      MANDATORY field.
       Peer address of the connected infra, as seen on the socket level
       of the CGW.
     type: string
   connect_message_payload:
     description:
+      MANDATORY field.
       Payload of infra CONNECT message
     type: string
   timestamp:
@@ -117,6 +131,7 @@ unassigned_infra_leave:
     type: integer
   infra_group_infra:
     description:
+      MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   timestamp:
@@ -139,15 +154,19 @@ foreign_infra_connection:
       ID of the shard that handled request and generated this response.
     type: integer
   infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
     description:
+      MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
   timestamp:
     description: MANDATORY field.
@@ -169,9 +188,12 @@ infrastructure_group_infra_capabilities_changed:
       ID of the shard that handled request and generated this response.
     type: integer
   infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
     description:
+      MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   changes:
@@ -183,6 +205,7 @@ infrastructure_group_infra_capabilities_changed:
       properties:
         changed:
           description:
+            MANDATORY field.
             String-value representing value that changed
           type: string
         old:
@@ -191,8 +214,9 @@ infrastructure_group_infra_capabilities_changed:
           type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
   timestamp:
     description: MANDATORY field.
@@ -210,28 +234,40 @@ ap_client_join:
     enum:
     - ap_client_join
   infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
     description:
+      MANDATORY field.
       MAC (serial) of the infra that connected the WiFi ssid of the infra.
     type: string
   client:
     description:
+      MANDATORY field.
       MAC (serial) of the infra client that joined.
     type: string
   ssid:
     description:
+      MANDATORY field.
       SSID that the underlying infra client joined.
     type: string
   band:
     description:
+      MANDATORY field.
       Band on which the underlying infra client joined.
     type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
+  sequence_number:
+    description:
+      MANDATORY field.
+      Represent the sequence number of topology change.
+    type: integer
   timestamp:
     description: MANDATORY field.
       (unix-epoch-time) 16 digits (microseconds) timestamp that indicates exact time
@@ -248,24 +284,35 @@ ap_client_leave:
     enum:
     - ap_client_leave
   infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
     description:
+      MANDATORY field.
       MAC (serial) of the infra that disconnected the WiFi ssid of the infra.
     type: string
   client:
     description:
+      MANDATORY field.
       MAC (serial) of the infra client that disconnected.
     type: string
   band:
     description:
+      MANDATORY field.
       Band on which the underlying infra client disconnected.
     type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
+  sequence_number:
+    description:
+      MANDATORY field.
+      Represent the sequence number of topology change.
+    type: integer
   timestamp:
     description: MANDATORY field.
       (unix-epoch-time) 16 digits (microseconds) timestamp that indicates exact time
@@ -283,28 +330,40 @@ ap_client_migrate:
     enum:
     - ap_client_migrate
   infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
     type: integer
   to_infra_group_infra_device:
     description:
+      MANDATORY field.
       MAC (serial) of the destination infra to which the WiFi client is migrating to.
     type: string
   client:
     description:
+      MANDATORY field.
       MAC (serial) of the infra client that joined.
     type: string
   to_ssid:
     description:
+      MANDATORY field.
       Destination SSID that the underlying infra client is migrating to.
     type: string
   to_band:
     description:
+      MANDATORY field.
       Destination band on which the underlying infra is migrating on.
     type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field is optional and might be empty JSON object or missed.
     type: string
+  sequence_number:
+    description:
+      MANDATORY field.
+      Represent the sequence number of topology change.
+    type: integer
   timestamp:
     description: MANDATORY field.
       (unix-epoch-time) 16 digits (microseconds) timestamp that indicates exact time
@@ -322,6 +381,7 @@ infrastructure_state_event_message:
     - infrastructure_state_event_message
   event_type:
     description:
+      MANDATORY field.
       The UCentral State/Healthcheck event type.
     type: string
   reporter_shard_id:
@@ -330,12 +390,14 @@ infrastructure_state_event_message:
     type: integer
   payload:
     description:
+      MANDATORY field.
       Payload of infra State or Healthcheck (UCentral) event message.
     type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
   timestamp:
     description: MANDATORY field.
@@ -354,6 +416,7 @@ infrastructure_realtime_event_message:
     - infrastructure_realtime_event_message
   event_type:
     description:
+      MANDATORY field.
       The UCentral Real-time event type (e.g. Log, Alarm, WifiScan, etc...).
     type: string
   reporter_shard_id:
@@ -362,12 +425,14 @@ infrastructure_realtime_event_message:
     type: integer
   payload:
     description:
+      MANDATORY field.
       Payload of infra Real-time (UCentral) event message.
     type: string
   cloud-header:
     description:
+      OPTIONAL field.
       The infrastructure group and infra cloud header.
-      This field is optional and might be empty JSON object or missed.
+      This field might be empty JSON object or missed.
     type: string
   timestamp:
     description: MANDATORY field.

--- a/api/events.yaml
+++ b/api/events.yaml
@@ -18,24 +18,20 @@ infra_join:
       Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   infra_public_ip:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Peer address of the connected infra, as seen on the socket level
       of the CGW.
     type: string
   connect_message_payload:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Payload of infra CONNECT message
     type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string
@@ -62,13 +58,11 @@ infra_leave:
       Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string
@@ -91,24 +85,20 @@ unassigned_infra_join:
       ID of the shard that handled request and generated this response.
     type: integer
   group_owner_shard_id:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       ID of the shard that is the actual owner of the infra group.
     type: integer
   infra_group_infra:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   infra_public_ip:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Peer address of the connected infra, as seen on the socket level
       of the CGW.
     type: string
   connect_message_payload:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Payload of infra CONNECT message
     type: string
   timestamp:
@@ -130,8 +120,7 @@ unassigned_infra_leave:
       ID of the shard that handled request and generated this response.
     type: integer
   infra_group_infra:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   timestamp:
@@ -158,13 +147,11 @@ foreign_infra_connection:
       Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string
@@ -192,8 +179,7 @@ infrastructure_group_infra_capabilities_changed:
       Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra that successfully connected to CGW.
     type: string
   changes:
@@ -204,8 +190,7 @@ infrastructure_group_infra_capabilities_changed:
       type: object
       properties:
         changed:
-          description:
-            MANDATORY field.
+          description: MANDATORY field.
             String-value representing value that changed
           type: string
         old:
@@ -213,8 +198,7 @@ infrastructure_group_infra_capabilities_changed:
         new:
           type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string
@@ -238,34 +222,28 @@ ap_client_join:
       Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra that connected the WiFi ssid of the infra.
     type: string
   client:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra client that joined.
     type: string
   ssid:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       SSID that the underlying infra client joined.
     type: string
   band:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Band on which the underlying infra client joined.
     type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string
   sequence_number:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Represent the sequence number of topology change.
     type: integer
   timestamp:
@@ -288,29 +266,24 @@ ap_client_leave:
       Infrastructure group ID to which infra belongs to.
     type: integer
   infra_group_infra:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra that disconnected the WiFi ssid of the infra.
     type: string
   client:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra client that disconnected.
     type: string
   band:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Band on which the underlying infra client disconnected.
     type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string
   sequence_number:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Represent the sequence number of topology change.
     type: integer
   timestamp:
@@ -334,34 +307,28 @@ ap_client_migrate:
       Infrastructure group ID to which infra belongs to.
     type: integer
   to_infra_group_infra_device:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the destination infra to which the WiFi client is migrating to.
     type: string
   client:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       MAC (serial) of the infra client that joined.
     type: string
   to_ssid:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Destination SSID that the underlying infra client is migrating to.
     type: string
   to_band:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Destination band on which the underlying infra is migrating on.
     type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field is optional and might be empty JSON object or missed.
     type: string
   sequence_number:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Represent the sequence number of topology change.
     type: integer
   timestamp:
@@ -380,8 +347,7 @@ infrastructure_state_event_message:
     enum:
     - infrastructure_state_event_message
   event_type:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       The UCentral State/Healthcheck event type.
     type: string
   reporter_shard_id:
@@ -389,13 +355,11 @@ infrastructure_state_event_message:
       ID of the shard that handled request and generated this response.
     type: integer
   payload:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Payload of infra State or Healthcheck (UCentral) event message.
     type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string
@@ -415,8 +379,7 @@ infrastructure_realtime_event_message:
     enum:
     - infrastructure_realtime_event_message
   event_type:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       The UCentral Real-time event type (e.g. Log, Alarm, WifiScan, etc...).
     type: string
   reporter_shard_id:
@@ -424,13 +387,11 @@ infrastructure_realtime_event_message:
       ID of the shard that handled request and generated this response.
     type: integer
   payload:
-    description:
-      MANDATORY field.
+    description: MANDATORY field.
       Payload of infra Real-time (UCentral) event message.
     type: string
   cloud-header:
-    description:
-      OPTIONAL field.
+    description: OPTIONAL field.
       The infrastructure group and infra cloud header.
       This field might be empty JSON object or missed.
     type: string
@@ -438,4 +399,66 @@ infrastructure_realtime_event_message:
     description: MANDATORY field.
       (unix-epoch-time) 16 digits (microseconds) timestamp that indicates exact time
       the event had been received by the CGW on the socket level.
+    type: integer
+
+ucantral_topomap_infra_join:
+  description:
+    Event, that CGW Topology MAP generates whenever UCentral infra connects to the CGW.
+  type:
+    description: MANDATORY field. Type should be parsed by NB services for matching.
+    type: string
+    enum:
+    - ucantral_topomap_infra_join
+  infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
+    type: integer
+  infra_group_infra:
+    description: MANDATORY field.
+      MAC (serial) of the infra that successfully connected to CGW.
+    type: string
+  cloud-header:
+    description: OPTIONAL field.
+      The infrastructure group and infra cloud header.
+      This field might be empty JSON object or missed.
+    type: string
+  sequence_number:
+    description: MANDATORY field.
+      Represent the sequence number of topology change.
+    type: integer
+  timestamp:
+    description: MANDATORY field.
+      (unix-epoch-time) 16 digits (microseconds) timestamp that indicates exact time
+      the event had been detected by the CGW.
+    type: integer
+
+ucantral_topomap_infra_leave:
+  description:
+    Event, that CGW Topology MAP generates whenever UCentral infra disconnects from the CGW.
+  type:
+    description: MANDATORY field. Type should be parsed by NB services for matching.
+    type: string
+    enum:
+    - ucantral_topomap_infra_leave
+  infra_group_id:
+    description: MANDATORY field.
+      Infrastructure group ID to which infra belongs to.
+    type: integer
+  infra_group_infra:
+    description: MANDATORY field.
+      MAC (serial) of the infra that successfully connected to CGW.
+    type: string
+  cloud-header:
+    description: OPTIONAL field.
+      The infrastructure group and infra cloud header.
+      This field might be empty JSON object or missed.
+    type: string
+  sequence_number:
+    description: MANDATORY field.
+      Represent the sequence number of topology change.
+    type: integer
+  timestamp:
+    description: MANDATORY field.
+      (unix-epoch-time) 16 digits (microseconds) timestamp that indicates exact time
+      the event had been detected by the CGW.
     type: integer

--- a/src/cgw_connection_server.rs
+++ b/src/cgw_connection_server.rs
@@ -2455,8 +2455,6 @@ impl CGWConnectionServer {
                     orig_connect_message,
                 ) = msg
                 {
-                    let device_platform: String = caps.platform.clone();
-
                     // if connection is unique: simply insert new conn
                     //
                     // if duplicate exists: notify server about such incident.
@@ -2557,30 +2555,29 @@ impl CGWConnectionServer {
                                 foreign_infra_join = self.local_cgw_id != group_owner_id;
                                 group_owner_shard_id = group_owner_id;
                             }
-                        } else {
-                            let device: CGWDevice = CGWDevice::new(
-                                device_type,
-                                CGWDeviceState::CGWDeviceConnected,
-                                device_group_id,
-                                false,
-                                caps,
-                            );
-                            devices_cache.add_device(&device_mac, &device);
+                        }
+                        let device: CGWDevice = CGWDevice::new(
+                            device_type,
+                            CGWDeviceState::CGWDeviceConnected,
+                            device_group_id,
+                            false,
+                            caps,
+                        );
+                        devices_cache.add_device(&device_mac, &device);
 
-                            // Update Redis Cache
-                            match serde_json::to_string(&device) {
-                                Ok(device_json) => {
-                                    if let Err(e) = self
-                                        .cgw_remote_discovery
-                                        .add_device_to_redis_cache(&device_mac, &device_json)
-                                        .await
-                                    {
-                                        error!("{e}");
-                                    }
+                        // Update Redis Cache
+                        match serde_json::to_string(&device) {
+                            Ok(device_json) => {
+                                if let Err(e) = self
+                                    .cgw_remote_discovery
+                                    .add_device_to_redis_cache(&device_mac, &device_json)
+                                    .await
+                                {
+                                    error!("{e}");
                                 }
-                                Err(e) => {
-                                    error!("Failed to serialize device to json string! Error: {e}");
-                                }
+                            }
+                            Err(e) => {
+                                error!("Failed to serialize device to json string! Error: {e}");
                             }
                         }
                     }
@@ -2706,7 +2703,7 @@ impl CGWConnectionServer {
                     if self.feature_topomap_enabled {
                         let topomap = CGWUCentralTopologyMap::get_ref();
                         topomap
-                            .insert_device(&device_mac, device_platform.as_str(), device_group_id)
+                            .insert_device(&device_mac, device_group_id, self.clone(), timestamp)
                             .await;
                     }
 

--- a/src/cgw_nb_api_listener.rs
+++ b/src/cgw_nb_api_listener.rs
@@ -243,6 +243,28 @@ pub struct APClientMigrateMessage {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct UCentralTopomapInfraJoin {
+    pub r#type: &'static str,
+    pub infra_group_id: i32,
+    pub infra_group_infra: MacAddress,
+    #[serde(default, rename = "cloud-header")]
+    pub cloud_header: Option<String>,
+    pub sequence_number: u64,
+    pub timestamp: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UCentralTopomapInfraLeave {
+    pub r#type: &'static str,
+    pub infra_group_id: i32,
+    pub infra_group_infra: MacAddress,
+    #[serde(default, rename = "cloud-header")]
+    pub cloud_header: Option<String>,
+    pub sequence_number: u64,
+    pub timestamp: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct InfraJoinMessage {
     pub r#type: &'static str,
     pub infra_group_id: i32,
@@ -848,6 +870,44 @@ pub fn cgw_construct_cloud_header(
     };
 
     cloud_header
+}
+
+pub fn cgw_construct_ucentral_topomap_infra_join_msg(
+    infra_group_id: i32,
+    infra_group_infra: MacAddress,
+    cloud_header: Option<String>,
+    sequence_number: u64,
+    timestamp: i64,
+) -> Result<String> {
+    let infra_leave_msg = UCentralTopomapInfraJoin {
+        r#type: "ucantral_topomap_infra_join",
+        infra_group_id,
+        infra_group_infra,
+        cloud_header,
+        sequence_number,
+        timestamp,
+    };
+
+    Ok(serde_json::to_string(&infra_leave_msg)?)
+}
+
+pub fn cgw_construct_ucentral_topomap_infra_leave_msg(
+    infra_group_id: i32,
+    infra_group_infra: MacAddress,
+    cloud_header: Option<String>,
+    sequence_number: u64,
+    timestamp: i64,
+) -> Result<String> {
+    let infra_leave_msg = UCentralTopomapInfraLeave {
+        r#type: "ucantral_topomap_infra_leave",
+        infra_group_id,
+        infra_group_infra,
+        cloud_header,
+        sequence_number,
+        timestamp,
+    };
+
+    Ok(serde_json::to_string(&infra_leave_msg)?)
 }
 
 pub fn cgw_get_timestamp_16_digits() -> i64 {

--- a/src/cgw_nb_api_listener.rs
+++ b/src/cgw_nb_api_listener.rs
@@ -211,6 +211,7 @@ pub struct APClientJoinMessage {
     pub band: String,
     #[serde(default, rename = "cloud-header")]
     pub cloud_header: Option<String>,
+    pub sequence_number: u64,
     pub timestamp: i64,
 }
 
@@ -223,6 +224,7 @@ pub struct APClientLeaveMessage {
     pub band: String,
     #[serde(default, rename = "cloud-header")]
     pub cloud_header: Option<String>,
+    pub sequence_number: u64,
     pub timestamp: i64,
 }
 
@@ -236,6 +238,7 @@ pub struct APClientMigrateMessage {
     pub to_band: String,
     #[serde(default, rename = "cloud-header")]
     pub cloud_header: Option<String>,
+    pub sequence_number: u64,
     pub timestamp: i64,
 }
 
@@ -616,6 +619,7 @@ pub fn cgw_construct_client_join_msg(
     ssid: String,
     band: String,
     cloud_header: Option<String>,
+    sequence_number: u64,
     timestamp: i64,
 ) -> Result<String> {
     let client_join_msg = APClientJoinMessage {
@@ -626,6 +630,7 @@ pub fn cgw_construct_client_join_msg(
         ssid,
         band,
         cloud_header,
+        sequence_number,
         timestamp,
     };
 
@@ -638,6 +643,7 @@ pub fn cgw_construct_client_leave_msg(
     infra_group_infra: MacAddress,
     band: String,
     cloud_header: Option<String>,
+    sequence_number: u64,
     timestamp: i64,
 ) -> Result<String> {
     let client_join_msg = APClientLeaveMessage {
@@ -647,6 +653,7 @@ pub fn cgw_construct_client_leave_msg(
         infra_group_infra,
         band,
         cloud_header,
+        sequence_number,
         timestamp,
     };
 
@@ -660,6 +667,7 @@ pub fn cgw_construct_client_migrate_msg(
     to_ssid: String,
     to_band: String,
     cloud_header: Option<String>,
+    sequence_number: u64,
     timestamp: i64,
 ) -> Result<String> {
     let client_migrate_msg = APClientMigrateMessage {
@@ -670,6 +678,7 @@ pub fn cgw_construct_client_migrate_msg(
         to_ssid,
         to_band,
         cloud_header,
+        sequence_number,
         timestamp,
     };
 


### PR DESCRIPTION
1) Moved Clients Join/Leave/Migrate handlers under lock in "process_device_topology_event" function.
2) Track seq. number for Client Join/Leave/Migrate events.