### PR TITLE
Dev update ap pasers

### DIFF
--- a/api/cnc_res_api.yaml
+++ b/api/cnc_res_api.yaml
@@ -391,6 +391,10 @@ infra_request_result:
           The unique identifier of the sender (kafka consumer id, for example),
           that uniquely identifies the single consumer within consumer group.
         type: integer
+  payload:
+     description: OPTIONAL field.
+      The original infra result response message. It might be empty if infra doesn't send response or
+      original request tiemed out.
   timestamp:
     description: MANDATORY field.
       (unix-epoch-time) 16 digits (microseconds) timestamp that indicates exact time

--- a/src/cgw_connection_processor.rs
+++ b/src/cgw_connection_processor.rs
@@ -603,11 +603,10 @@ impl CGWConnectionProcessor {
                                 } else {
                                     error!("Failed to construct infra_realtime_event message!");
                                 }
-                            },
+                            }
                             CGWUCentralEventType::Unknown => {
                                 error!("Received unknown event type! Message payload: {kafka_msg}");
                             }
-                            
                         }
                     }
 

--- a/src/cgw_connection_processor.rs
+++ b/src/cgw_connection_processor.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     cgw_ucentral_parser::{
         cgw_ucentral_event_parse, cgw_ucentral_parse_connect_event, CGWUCentralCommandType,
-        CGWUCentralEventType,
+        CGWUCentralEventType, CGWUCentralReplyType,
     },
     cgw_ucentral_topology_map::CGWUCentralTopologyMap,
 };
@@ -448,6 +448,13 @@ impl CGWConnectionProcessor {
                                         "Pending request ID {} is not equal received reply ID {}!",
                                         pending_req_id, content.id
                                     );
+                                }
+
+                                if let Some(reply_type) = content.reply_type {
+                                    if reply_type == CGWUCentralReplyType::Pending {
+                                        warn!("CGW Receive Reply for req id: {}, with result type: {}. Waiting for result Done result!", content.id, reply_type);
+                                        return Ok(CGWConnectionState::IsActive);
+                                    }
                                 }
 
                                 let partition = match pending_req_consumer_metadata.clone() {

--- a/src/cgw_connection_server.rs
+++ b/src/cgw_connection_server.rs
@@ -2024,13 +2024,15 @@ impl CGWConnectionServer {
                         let connmap_r_lock = self.connmap.map.read().await;
 
                         for (infra_mac, _) in connmap_r_lock.iter() {
-                            if !self
-                                .devices_cache
-                                .read()
-                                .await
-                                .check_device_exists(infra_mac)
-                            {
-                                infras_list.push(*infra_mac);
+                            match self.devices_cache.read().await.get_device(infra_mac) {
+                                Some(infra) => {
+                                    if infra.get_device_group_id() == 0 {
+                                        infras_list.push(*infra_mac);
+                                    }
+                                },
+                                None => {
+                                    infras_list.push(*infra_mac);
+                                },
                             }
                         }
 

--- a/src/cgw_connection_server.rs
+++ b/src/cgw_connection_server.rs
@@ -2961,6 +2961,7 @@ impl CGWConnectionServer {
                         None => None,
                     };
 
+                    // Requests does not receive Reply - so payload is None
                     if let Ok(resp) = cgw_construct_infra_request_result_msg(
                         self.local_cgw_id,
                         req.uuid,
@@ -2969,6 +2970,7 @@ impl CGWConnectionServer {
                         false,
                         Some(format!("Request failed due to infra {} disconnect", infra)),
                         req.consumer_metadata,
+                        None,
                         timestamp,
                     ) {
                         self.enqueue_mbox_message_from_cgw_to_nb_api(

--- a/src/cgw_device.rs
+++ b/src/cgw_device.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub enum CGWDeviceType {
     CGWDeviceAP,
     CGWDeviceSwitch,

--- a/src/cgw_devices_cache.rs
+++ b/src/cgw_devices_cache.rs
@@ -57,6 +57,16 @@ impl CGWDevicesCache {
         status
     }
 
+    pub fn replace_device(&mut self, key: &MacAddress, value: &CGWDevice) {
+        if self.check_device_exists(key) {
+            debug!(
+                "Replacing existing device {}. Requested item already exist",
+                key
+            );
+        }
+        self.cache.insert(*key, value.clone());
+    }
+
     pub fn check_device_exists(&self, key: &MacAddress) -> bool {
         self.cache.contains_key(key)
     }
@@ -86,10 +96,6 @@ impl CGWDevicesCache {
         CGWDevicesCacheIterMutable {
             iter: self.cache.iter_mut(),
         }
-    }
-
-    pub fn flush_all(&mut self) {
-        self.cache.clear();
     }
 
     pub fn dump_devices_cache(&self) {

--- a/src/cgw_nb_api_listener.rs
+++ b/src/cgw_nb_api_listener.rs
@@ -142,6 +142,7 @@ pub struct InfraGroupInfraRequestResult {
     pub success: bool,
     pub error_message: Option<String>,
     pub consumer_metadata: Option<ConsumerMetadata>,
+    pub payload: Option<String>,
     pub timestamp: i64,
 }
 
@@ -701,6 +702,7 @@ pub fn cgw_construct_infra_request_result_msg(
     success: bool,
     error_message: Option<String>,
     consumer_metadata: Option<ConsumerMetadata>,
+    payload: Option<String>,
     timestamp: i64,
 ) -> Result<String> {
     let infra_request_result = InfraGroupInfraRequestResult {
@@ -712,6 +714,7 @@ pub fn cgw_construct_infra_request_result_msg(
         success,
         error_message,
         consumer_metadata,
+        payload,
         timestamp,
     };
 

--- a/src/cgw_remote_discovery.rs
+++ b/src/cgw_remote_discovery.rs
@@ -1919,9 +1919,7 @@ impl CGWRemoteDiscovery {
         &self,
         cache: Arc<RwLock<CGWDevicesCache>>,
     ) -> Result<()> {
-        // flush cache
         let mut devices_cache = cache.write().await;
-        devices_cache.flush_all();
 
         let mut con = self.redis_infra_cache_client.clone();
         let key = format!("shard_id_{}|*", self.local_shard_id);
@@ -1987,7 +1985,7 @@ impl CGWRemoteDiscovery {
 
             match serde_json::from_str(&device_str) {
                 Ok(dev) => {
-                    devices_cache.add_device(&device_mac, &dev);
+                    devices_cache.replace_device(&device_mac, &dev);
                     CGWMetrics::get_ref()
                         .change_group_counter(
                             dev.get_device_group_id(),

--- a/src/cgw_ucentral_ap_parser.rs
+++ b/src/cgw_ucentral_ap_parser.rs
@@ -807,10 +807,11 @@ fn parse_realtime_event_data(
                 decompressed: None,
             })
         }
-        _ => {
-            warn!("Received unknown event: {evt_type}!");
-            Err(Error::UCentralParser("Received unknown event"))
-        }
+        _ => Ok(CGWUCentralEvent {
+            serial,
+            evt_type: CGWUCentralEventType::Generic(evt_type.to_string()),
+            decompressed: None,
+        }),
     }
 }
 

--- a/src/cgw_ucentral_ap_parser.rs
+++ b/src/cgw_ucentral_ap_parser.rs
@@ -14,7 +14,7 @@ use crate::cgw_ucentral_parser::{
     CGWUCentralEventReply, CGWUCentralEventState, CGWUCentralEventStateClients,
     CGWUCentralEventStateClientsData, CGWUCentralEventStateClientsType,
     CGWUCentralEventStateLLDPData, CGWUCentralEventStateLinks, CGWUCentralEventStatePort,
-    CGWUCentralEventType, CGWUCentralJRPCMessage,
+    CGWUCentralEventType, CGWUCentralJRPCMessage, CGWUCentralReplyType,
 };
 
 fn parse_lldp_data(
@@ -940,9 +940,43 @@ pub fn cgw_ucentral_ap_parse_message(
                 return Err(Error::UCentralParser("Received JRPC <result> without id"));
             }
 
+            let mut reply_type: Option<CGWUCentralReplyType> = None;
+            if let Value::Object(status) = &result["status"] {
+                if let Some(status_result) = status.get("result") {
+                    match status_result.as_str() {
+                        Some(type_str) => {
+                            match CGWUCentralReplyType::try_from(type_str.to_string()) {
+                                Ok(t) => {
+                                    reply_type = Some(t);
+                                }
+                                Err(_e) => {
+                                    warn!("Received JRPC <result> with unexpected result: {type_str}!");
+                                    return Err(Error::UCentralParser(
+                                        "Received JRPC <result> with unexpected result",
+                                    ));
+                                }
+                            }
+                        }
+                        None => {
+                            warn!(
+                                "Failed to convert JRPC <result> status result to string: {:?}!",
+                                status_result
+                            );
+                            return Err(Error::UCentralParser(
+                                "Received JRPC <result> with unexpected result",
+                            ));
+                        }
+                    }
+                }
+            }
+
             let reply_event = CGWUCentralEvent {
                 serial: Default::default(),
-                evt_type: CGWUCentralEventType::Reply(CGWUCentralEventReply { id, payload: message.to_string() }),
+                evt_type: CGWUCentralEventType::Reply(CGWUCentralEventReply {
+                    id,
+                    payload: message.to_string(),
+                    reply_type,
+                }),
                 decompressed: None,
             };
 

--- a/src/cgw_ucentral_ap_parser.rs
+++ b/src/cgw_ucentral_ap_parser.rs
@@ -942,7 +942,7 @@ pub fn cgw_ucentral_ap_parse_message(
 
             let reply_event = CGWUCentralEvent {
                 serial: Default::default(),
-                evt_type: CGWUCentralEventType::Reply(CGWUCentralEventReply { id }),
+                evt_type: CGWUCentralEventType::Reply(CGWUCentralEventReply { id, payload: message.to_string() }),
                 decompressed: None,
             };
 

--- a/src/cgw_ucentral_ap_parser.rs
+++ b/src/cgw_ucentral_ap_parser.rs
@@ -906,15 +906,39 @@ pub fn cgw_ucentral_ap_parse_message(
             decompressed: None,
         });
     } else if map.contains_key("result") {
+        let mut id: u64 = 0;
+        let mut id_found: bool = false;
+
+        // Try to find ID in message root scope.
+        if map.contains_key("id") {
+            id = map["id"]
+                .as_u64()
+                .ok_or_else(|| Error::UCentralParser("Failed to parse id"))?;
+            id_found = true;
+        }
+
         if let Value::Object(result) = &map["result"] {
-            if !result.contains_key("id") {
+            // Try to find ID in message result scope.
+            if result.contains_key("id") {
+                id = result["id"]
+                    .as_u64()
+                    .ok_or_else(|| Error::UCentralParser("Failed to parse id"))?;
+                id_found = true;
+            } else if let Some(Value::Object(state)) = result.get("state") {
+                // Try to find ID in message state scope.
+                if state.contains_key("id") {
+                    id = result["id"]
+                        .as_u64()
+                        .ok_or_else(|| Error::UCentralParser("Failed to parse id"))?;
+                    id_found = true;
+                }
+            }
+
+            if !id_found {
                 warn!("Received JRPC <result> without id!");
                 return Err(Error::UCentralParser("Received JRPC <result> without id"));
             }
 
-            let id = result["id"]
-                .as_u64()
-                .ok_or_else(|| Error::UCentralParser("Failed to parse id"))?;
             let reply_event = CGWUCentralEvent {
                 serial: Default::default(),
                 evt_type: CGWUCentralEventType::Reply(CGWUCentralEventReply { id }),

--- a/src/cgw_ucentral_ap_parser.rs
+++ b/src/cgw_ucentral_ap_parser.rs
@@ -833,7 +833,7 @@ pub fn cgw_ucentral_ap_parse_message(
             warn!("Received malformed JSONRPC msg!");
             Error::UCentralParser("JSONRPC field is missing in message")
         })?;
-        let mut event_type: CGWUCentralEventType = CGWUCentralEventType::Unknown;
+        let event_type: CGWUCentralEventType;
         if method == "connect" {
             let params = map
                 .get("params")
@@ -899,6 +899,8 @@ pub fn cgw_ucentral_ap_parse_message(
             event_type = CGWUCentralEventType::Recovery;
         } else if method == "venue_broadcast" {
             event_type = CGWUCentralEventType::VenueBroadcast;
+        } else {
+            event_type = CGWUCentralEventType::Generic(method.to_string());
         }
 
         return Ok(CGWUCentralEvent {

--- a/src/cgw_ucentral_parser.rs
+++ b/src/cgw_ucentral_parser.rs
@@ -195,6 +195,7 @@ pub struct CGWUCentralEventState {
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CGWUCentralEventReply {
     pub id: u64,
+    pub payload: String,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq)]

--- a/src/cgw_ucentral_parser.rs
+++ b/src/cgw_ucentral_parser.rs
@@ -196,6 +196,7 @@ pub struct CGWUCentralEventState {
 pub struct CGWUCentralEventReply {
     pub id: u64,
     pub payload: String,
+    pub reply_type: Option<CGWUCentralReplyType>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
@@ -272,6 +273,33 @@ impl std::fmt::Display for CGWUCentralEventType {
             CGWUCentralEventType::Reply(_) => write!(f, "reply"),
             CGWUCentralEventType::Generic(_) => write!(f, "generic"),
             CGWUCentralEventType::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub enum CGWUCentralReplyType {
+    Pending,
+    Done,
+}
+
+impl std::fmt::Display for CGWUCentralReplyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            CGWUCentralReplyType::Pending => write!(f, "Pending"),
+            CGWUCentralReplyType::Done => write!(f, "Done"),
+        }
+    }
+}
+
+impl TryFrom<String> for CGWUCentralReplyType {
+    type Error = crate::Error;
+
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        match value.as_str() {
+            "pending" => Ok(CGWUCentralReplyType::Pending),
+            "done" => Ok(CGWUCentralReplyType::Done),
+            _ => Err(Error::UCentralParser("Message to string cast failed")),
         }
     }
 }

--- a/src/cgw_ucentral_parser.rs
+++ b/src/cgw_ucentral_parser.rs
@@ -244,6 +244,7 @@ pub enum CGWUCentralEventType {
     VenueBroadcast,
     RealtimeEvent(CGWUCentralEventRealtimeEvent),
     Reply(CGWUCentralEventReply),
+    Generic(String),
     Unknown,
 }
 
@@ -268,6 +269,7 @@ impl std::fmt::Display for CGWUCentralEventType {
                 write!(f, "realtime_event")
             }
             CGWUCentralEventType::Reply(_) => write!(f, "reply"),
+            CGWUCentralEventType::Generic(_) => write!(f, "generic"),
             CGWUCentralEventType::Unknown => write!(f, "unknown"),
         }
     }

--- a/src/cgw_ucentral_switch_parser.rs
+++ b/src/cgw_ucentral_switch_parser.rs
@@ -300,7 +300,7 @@ pub fn cgw_ucentral_switch_parse_message(
 
             let reply_event = CGWUCentralEvent {
                 serial: Default::default(),
-                evt_type: CGWUCentralEventType::Reply(CGWUCentralEventReply { id }),
+                evt_type: CGWUCentralEventType::Reply(CGWUCentralEventReply { id, payload: message.to_string() }),
                 decompressed: None,
             };
 

--- a/src/cgw_ucentral_switch_parser.rs
+++ b/src/cgw_ucentral_switch_parser.rs
@@ -255,6 +255,8 @@ pub fn cgw_ucentral_switch_parse_message(
             event_type = CGWUCentralEventType::Recovery;
         } else if method == "venue_broadcast" {
             event_type = CGWUCentralEventType::VenueBroadcast;
+        } else {
+            event_type = CGWUCentralEventType::Generic(method.to_string());
         }
 
         return Ok(CGWUCentralEvent {


### PR DESCRIPTION
CGW Stability update:
1) Drop CONFIG request for infras that has never been connected to CGW,
2) Search for infra request reply id in different scopes to avoid potential issues with Reply message format.
3) Parse generic events (method and event types)
4) Envelop original CONNECT message for [un]assigned infra join on GID change event.
5) Envelop original Reply message into infra response reply.
6) Make CGW to send single infra response reply to NB: AP might send reply with status pending and done. CGW should update NB only on Done result type.