### PR TITLE
Connection Processor: ignore processing of requests from unassigned i…

### DIFF
--- a/src/cgw_connection_processor.rs
+++ b/src/cgw_connection_processor.rs
@@ -358,6 +358,12 @@ impl CGWConnectionProcessor {
                     return Ok(CGWConnectionState::ClosedGracefully);
                 }
                 Text(payload) => {
+                    // Infra not assigned?
+                    // No need to even try and process any messages at all.
+                    if self.group_id == 0 {
+                        return Ok(CGWConnectionState::IsActive);
+                    }
+
                     if let Ok(evt) = cgw_ucentral_event_parse(
                         &self.device_type,
                         self.feature_topomap_enabled,
@@ -388,12 +394,6 @@ impl CGWConnectionProcessor {
                                     );
                                 }
 
-                                if self.group_id == 0 {
-                                    // This infra is unassigned - CGW SHOULD NOT
-                                    // send State/Infra Realtime event to NB
-                                    return Ok(CGWConnectionState::IsActive);
-                                }
-
                                 if let Ok(resp) = cgw_construct_infra_state_event_message(
                                     event_type_str,
                                     kafka_msg,
@@ -412,12 +412,6 @@ impl CGWConnectionProcessor {
                                 }
                             }
                             CGWUCentralEventType::Healthcheck => {
-                                if self.group_id == 0 {
-                                    // This infra is unassigned - CGW SHOULD NOT
-                                    // send State/Infra Realtime event to NB
-                                    return Ok(CGWConnectionState::IsActive);
-                                }
-
                                 if let Ok(resp) = cgw_construct_infra_state_event_message(
                                     event_type_str,
                                     kafka_msg,
@@ -520,12 +514,6 @@ impl CGWConnectionProcessor {
                                     );
                                 }
 
-                                if self.group_id == 0 {
-                                    // This infra is unassigned - CGW SHOULD NOT
-                                    // send State/Infra Realtime event to NB
-                                    return Ok(CGWConnectionState::IsActive);
-                                }
-
                                 if let Ok(resp) = cgw_construct_infra_realtime_event_message(
                                     event_type_str,
                                     kafka_msg,
@@ -557,12 +545,6 @@ impl CGWConnectionProcessor {
                             | CGWUCentralEventType::CfgPending
                             | CGWUCentralEventType::DeviceUpdate
                             | CGWUCentralEventType::Recovery => {
-                                if self.group_id == 0 {
-                                    // This infra is unassigned - CGW SHOULD NOT
-                                    // send State/Infra Realtime event to NB
-                                    return Ok(CGWConnectionState::IsActive);
-                                }
-
                                 if let Ok(resp) = cgw_construct_infra_realtime_event_message(
                                     event_type_str,
                                     kafka_msg,
@@ -581,12 +563,6 @@ impl CGWConnectionProcessor {
                                 }
                             }
                             CGWUCentralEventType::Generic(generic_type) => {
-                                if self.group_id == 0 {
-                                    // This infra is unassigned - CGW SHOULD NOT
-                                    // send State/Infra Realtime event to NB
-                                    return Ok(CGWConnectionState::IsActive);
-                                }
-
                                 if let Ok(resp) = cgw_construct_infra_realtime_event_message(
                                     generic_type,
                                     kafka_msg,

--- a/utils/kafka_producer/main.py
+++ b/utils/kafka_producer/main.py
@@ -6,6 +6,11 @@ from src.log import logger
 
 def main(args: Args):
     producer = Producer(args.db, args.topic)
+    if args.add_groups_to_shard:
+        producer.connect()
+        for (group, shard) in args.add_groups_to_shard:
+            print("gid: " + str(group) + ", shard id:", shard)
+            producer.handle_single_group_create(group=group, uuid_val=1, shard_id=shard)
     if args.add_groups or args.del_groups:
         producer.handle_group_creation(args.add_groups, args.del_groups)
     if args.assign_to_group or args.remove_from_group:

--- a/utils/kafka_producer/single_group_add_to_shard.sh
+++ b/utils/kafka_producer/single_group_add_to_shard.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Although we're looking for broker at localhost,
+# broker can still direct us to some <docker-broker-1>
+# so it's up to the caller to either run this script inside
+# the same network instance as broker, or create a static
+# hostname entry to point <docker-broker-1>, for example,
+# to whenever it resides.
+#
+# ARGS:
+# $1 - group id
+# $2 - shard id
+./run.sh -s localhost:9092 -c 1 --new-group-to-shard $1 $2

--- a/utils/kafka_producer/src/cli_parser.py
+++ b/utils/kafka_producer/src/cli_parser.py
@@ -64,6 +64,9 @@ def parse_args():
     parser.add_argument("-ih", "--infras-header", metavar=("GROUP-ID", "MAC-RANGE"),
                         nargs=2, action="append",
                         help="set group infras header")
+    parser.add_argument("-GI", "--new-group-to-shard", metavar=("GROUP-ID"), type=int,
+                        nargs=2, action="append",
+                        help="create a new group and assign it to specific shard (by id)")
 
     parsed_args = parser.parse_args()
 
@@ -98,7 +101,8 @@ def parse_args():
         group_id=parsed_args.send_to_group,
         send_to_macs=parsed_args.send_to_mac,
         header_group=[],
-        header_infras=[]
+        header_infras=[],
+        add_groups_to_shard=[]
     )
     if parsed_args.new_group is not None:
         for (group,) in parsed_args.new_group:
@@ -106,6 +110,12 @@ def parse_args():
                 args.add_groups.append(group)
             except ValueError:
                 parser.error(f"--new-group: failed to parse {group}")
+    if parsed_args.new_group_to_shard is not None:
+        for (group,shard) in parsed_args.new_group_to_shard:
+            try:
+                args.add_groups_to_shard.append((group, shard))
+            except ValueError:
+                parser.error(f"----new-group-to-shard: failed to parse {group}/{shard}")
     if parsed_args.rm_group is not None:
         for (group,) in parsed_args.rm_group:
             args.del_groups.append(group)

--- a/utils/kafka_producer/src/producer.py
+++ b/utils/kafka_producer/src/producer.py
@@ -175,11 +175,15 @@ class Producer:
                            bytes(str(group), encoding="utf-8"))
         self.conn.flush()
 
-    def handle_group_creation(self, create: List[int], delete: List[int]) -> None:
+    def handle_group_creation(self, create: List[int], delete: List[int], shard_id: int = None) -> None:
         with self as conn:
             for group in create:
-                conn.send(self.topic, self.message.group_create(group),
-                          bytes(str(group), encoding="utf-8"))
+                if shard_id:
+                    conn.send(self.topic, self.message.group_create_to_shard(group, shard_id),
+                              bytes(str(group), encoding="utf-8"))
+                else:
+                    conn.send(self.topic, self.message.group_create(group),
+                              bytes(str(group), encoding="utf-8"))
             for group in delete:
                 conn.send(self.topic, self.message.group_delete(group),
                           bytes(str(group), encoding="utf-8"))

--- a/utils/kafka_producer/src/utils.py
+++ b/utils/kafka_producer/src/utils.py
@@ -315,3 +315,4 @@ class Args:
     send_to_macs: MacRange
     header_group: List[int]
     header_infras: List[Tuple[int, MacRange]]
+    add_groups_to_shard: List[Tuple[int, int]]


### PR DESCRIPTION
…nfras

GID 0 (unassigned) infras are not a subject to uCentral event processing (state, rt events, logs etc).
Thus, there's no need to burn CPU for infras, whose messages would be rejected afterall after they're parsed.

Also:
* Fixup fill_groups to have possibility to assign group to specific shard;
* add utils assign gid to shard script (+tweaks in main.py);