### PR TITLE
CGW: bump redis-related timeouts

### DIFF
--- a/src/cgw_kafka_init.rs
+++ b/src/cgw_kafka_init.rs
@@ -31,8 +31,8 @@ async fn cgw_get_active_cgw_number(redis_args: &CGWRedisArgs) -> Result<usize> {
 
     let mut redis_connection = match redis_client
         .get_multiplexed_tokio_connection_with_response_timeouts(
-            Duration::from_secs(1),
-            Duration::from_secs(5),
+            Duration::from_secs(15),
+            Duration::from_secs(15),
         )
         .await
     {

--- a/src/cgw_remote_discovery.rs
+++ b/src/cgw_remote_discovery.rs
@@ -359,8 +359,8 @@ impl CGWRemoteDiscovery {
 
         let redis_client = match redis_client
             .get_multiplexed_tokio_connection_with_response_timeouts(
-                Duration::from_secs(1),
-                Duration::from_secs(5),
+                Duration::from_secs(15),
+                Duration::from_secs(15),
             )
             .await
         {
@@ -388,8 +388,8 @@ impl CGWRemoteDiscovery {
 
         let mut redis_infra_cache_client = match redis_infra_cache_client
             .get_multiplexed_tokio_connection_with_response_timeouts(
-                Duration::from_secs(1),
-                Duration::from_secs(5),
+                Duration::from_secs(15),
+                Duration::from_secs(15),
             )
             .await
         {


### PR DESCRIPTION
Long replies is better than pod that is crashing due to unhealthy state