### PR TITLE
[#1][WIFI-15157][OpenLAN CGW]  Resolved shard ownership of infra on device connection

### DIFF
--- a/src/cgw_db_accessor.rs
+++ b/src/cgw_db_accessor.rs
@@ -309,6 +309,34 @@ impl CGWDBAccessor {
         }
     }
 
+    pub async fn get_infra_group_id_by_mac(&self, mac: MacAddress) -> Option<i32> {
+        let query = match self
+            .cl
+            .prepare("SELECT infra_group_id FROM infras WHERE mac = $1")
+            .await
+        {
+            Ok(q) => q,
+            Err(e) => {
+                error!("Failed to prepare query for get_infra_group_id_by_mac! Error: {e}");
+                return None;
+            }
+        };
+
+        let result = self.cl.query_opt(&query, &[&mac]).await;
+
+        match result {
+            Ok(Some(row)) => Some(row.get::<_, i32>("infra_group_id")),
+            Ok(None) => {
+                debug!("No infra found in DB for mac: {}", mac.to_hex_string());
+                None
+            }
+            Err(e) => {
+                error!("Query failed for get_infra_group_id_by_mac! Error: {e}");
+                None
+            }
+        }
+    }
+
     pub async fn get_all_infras(&self) -> Option<Vec<CGWDBInfra>> {
         let mut list: Vec<CGWDBInfra> = Vec::new();
 


### PR DESCRIPTION

Root cause:
- Each shard caches only its own details.
- When an AP (gateway) connects to a non-owner shard, that shard cannot determine whether the device is truly unassigned or owned by another shard.

Solution:
- On local cache miss, query Redis/DB for existing infra group.
- Resolve ownership: emit Kafka event (foreign/unassigned).
- Purge the device from all shard Redis caches to prevent stale entries.

Test:
- Build passes OK!.
- Verified no regression.